### PR TITLE
v0.1.0: Azure backend, grove-style TUI with filters and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,34 @@ refresh_secs: 300
 
 ### Supported backends
 
-| Backend | `backend:` value | Required fields |
-|---------|-----------------|-----------------|
-| Azure Boards | `azure-boards` | `org`, `project` |
-| GitHub Issues | `github` | `owner`, `repos` |
-| Jira | `jira` | `url`, `project` |
-| Linear | `linear` | `team_id` |
+| Backend | `backend:` value | Required fields | Status |
+|---------|-----------------|-----------------|--------|
+| Azure Boards | `azure-boards` | `org`, `project` | Implemented |
+| GitHub Issues | `github` | `owner`, `repos` | Stubbed |
+| Jira | `jira` | `url`, `project` | Stubbed |
+| Linear | `linear` | `team_id` | Stubbed |
+
+### Authentication
+
+**Azure Boards** requires a Personal Access Token (PAT) with Work Items read scope. Provide it via:
+
+1. Environment variable: `export AZURE_DEVOPS_PAT=your-token`
+2. Token file: add `token_file: /path/to/pat` to the profile (works with sops-nix)
+
+Optional: set `azure_team` on the profile if your Azure DevOps team name differs from the default `"{project} Team"`.
+
+### View filters
+
+Views support these filter fields:
+
+| Filter | Values | Example |
+|--------|--------|---------|
+| `updated_since` | `today`, `yesterday`, `last_week`, `last_2_weeks`, `last_month`, `last_quarter` | `last_week` |
+| `types` | `feature`, `bug`, `user-story`, `task`, `epic` | `[feature, bug]` |
+| `status` | `todo`, `in-progress`, `in-review`, `done`, `closed` | `[done, in-progress]` |
+| `sprint` | `current`, or a sprint/iteration name | `current` |
+| `assignee` | `me`, or a name/email | `me` |
+| `labels` | tag names | `[frontend, priority-high]` |
 
 ### Files
 
@@ -91,12 +113,16 @@ refresh_secs: 300
 |-----|--------|
 | `h` / `l` | Previous / next tab |
 | `j` / `k` | Move down / up |
+| `g` / `G` | First / last item |
 | `1` `2` `3` | Switch to tab directly |
+| `r` | Refresh tasks |
+| `enter` | Select view (Views tab) |
+| `o` | Open task in browser |
 | `q` / `ctrl+c` | Quit |
 
 ## Status
 
-Canopy is in early development. Backend implementations are stubbed — Azure Boards will be the first to be fully implemented.
+Azure Boards is fully implemented. GitHub Issues, Jira, and Linear backends are stubbed and ready for implementation.
 
 ## License
 

--- a/cmd/canopy/config.example.yaml
+++ b/cmd/canopy/config.example.yaml
@@ -65,5 +65,13 @@ views:
     filters:
       assignee: me
 
+# Preset tags for the t cycle filter. These always appear first;
+# tags discovered from task data are appended automatically.
+tags:
+  # - blocked
+  # - tech-debt
+  # - needs-review
+  # - P1
+
 # How often (in seconds) the dashboard auto-refreshes in the background.
 refresh_secs: 300

--- a/cmd/canopy/config.example.yaml
+++ b/cmd/canopy/config.example.yaml
@@ -5,12 +5,12 @@
 # Profiles connect to task backends. Each profile targets one project/org.
 profiles:
   # Azure Boards example
+  # Authenticates via `az` CLI — run `az login` before starting canopy.
   - name: Work
     backend: azure-boards
     org: my-azure-org         # Azure DevOps organisation
     project: my-project       # Azure DevOps project name
     # azure_team: My Team     # optional: defaults to "{project} Team"
-    # token_file: /run/secrets/azure-devops-pat  # or set AZURE_DEVOPS_PAT env var
     team:                     # team members to track (display names or emails)
       - alice@example.com
       - bob@example.com

--- a/cmd/canopy/config.example.yaml
+++ b/cmd/canopy/config.example.yaml
@@ -9,6 +9,8 @@ profiles:
     backend: azure-boards
     org: my-azure-org         # Azure DevOps organisation
     project: my-project       # Azure DevOps project name
+    # azure_team: My Team     # optional: defaults to "{project} Team"
+    # token_file: /run/secrets/azure-devops-pat  # or set AZURE_DEVOPS_PAT env var
     team:                     # team members to track (display names or emails)
       - alice@example.com
       - bob@example.com

--- a/cmd/canopy/main.go
+++ b/cmd/canopy/main.go
@@ -38,7 +38,13 @@ func main() {
 	defer logFile.Close()
 
 	p := tea.NewProgram(
-		app.New(cfg),
+		app.New(app.Options{
+			Cfg:      cfg,
+			Version:  "0.1.0",
+			LogPath:  config.LogPath(),
+			CfgPath:  config.ConfigPath(),
+			CacheDir: config.CacheDir(),
+		}),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
 	)

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -1,0 +1,74 @@
+// Headless smoke test — exercises the Azure Boards backend without the TUI.
+// Run: go run ./cmd/smoke
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/alcxyz/canopy/internal/backend"
+	"github.com/alcxyz/canopy/internal/config"
+)
+
+func main() {
+	cfg := config.Load()
+	if len(cfg.Profiles) == 0 {
+		fmt.Fprintln(os.Stderr, "no profiles configured")
+		os.Exit(1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, p := range cfg.Profiles {
+		b, err := backend.New(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "profile %q: %v\n", p.Name, err)
+			continue
+		}
+
+		fmt.Printf("=== Profile: %s ===\n\n", b.Name())
+
+		// Sprints
+		sprints, err := b.ListSprints(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  sprints error: %v\n", err)
+		} else {
+			fmt.Printf("Sprints (%d):\n", len(sprints))
+			for _, s := range sprints {
+				fmt.Printf("  %s  %s → %s\n", s.Name, s.StartDate.Format("2006-01-02"), s.EndDate.Format("2006-01-02"))
+			}
+		}
+
+		// My tasks
+		fmt.Println()
+		myTasks, err := b.ListTasks(ctx, config.Filter{Assignee: "me"})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  my tasks error: %v\n", err)
+		} else {
+			fmt.Printf("My Tasks (%d):\n", len(myTasks))
+			for _, t := range myTasks {
+				parent := ""
+				if t.ParentTitle != "" {
+					parent = fmt.Sprintf(" [parent: %s]", t.ParentTitle)
+				}
+				fmt.Printf("  [%s] %s — %s (%s)%s\n", t.State, t.ID, t.Title, t.Type, parent)
+			}
+		}
+
+		// Team tasks (all)
+		fmt.Println()
+		teamTasks, err := b.ListTasks(ctx, config.Filter{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  team tasks error: %v\n", err)
+		} else {
+			fmt.Printf("Team Tasks (%d):\n", len(teamTasks))
+			for _, t := range teamTasks {
+				fmt.Printf("  [%s] %-12s %s — %s (%s)\n", t.State, t.Assignee, t.ID, t.Title, t.Type)
+			}
+		}
+		fmt.Println()
+	}
+}

--- a/docs/adr/ADR-002-azure-auth-via-az-cli.md
+++ b/docs/adr/ADR-002-azure-auth-via-az-cli.md
@@ -1,0 +1,35 @@
+# ADR-002: Azure authentication via az CLI
+
+**Status:** Accepted
+**Date:** 2026-04-22
+**Applies to:** `internal/backend/azure.go`
+
+## Context
+
+The Azure Boards backend currently authenticates using a Personal Access Token (PAT) sourced from either the `AZURE_DEVOPS_PAT` environment variable or a file path specified in the profile config (`token_file`). PATs are long-lived secrets that must be manually rotated, stored somewhere on disk, and re-issued when they expire. In organisations that enforce Conditional Access or SSO/MFA, PATs can also be outright blocked or scoped in ways that require re-approval over time.
+
+Users interacting with Azure DevOps from a terminal already have `az` (azure-cli) installed for other Azure work. When logged in via `az login`, the CLI holds a short-lived OAuth token that is automatically refreshed. Canopy can delegate auth entirely to that existing session.
+
+## Decision
+
+Acquire Azure DevOps access tokens by shelling out to `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798` (the Azure DevOps resource ID). The returned JSON contains an `accessToken` field which is used as a Bearer token on all requests instead of Basic auth with a PAT.
+
+This becomes the primary auth path for the Azure Boards backend. PAT-based auth (`AZURE_DEVOPS_PAT` / `token_file`) is removed; users who need non-interactive auth (CI, service accounts) should configure a credential via `az login --service-principal`.
+
+## Alternatives Considered
+
+**Keep PAT in env var or file (current approach).** Rejected because long-lived secrets in files or shell history are an unnecessary risk, and PATs don't work in orgs with Conditional Access without extra admin steps.
+
+**Built-in OAuth device-flow.** Rejected as significantly more complex to implement (OAuth client registration, token storage, refresh logic) with no advantage over the az CLI path for users who already have it installed.
+
+**Service principal client credentials in config.** Rejected for the same reasons as PATs — long-lived secrets in config files. The az CLI already handles service principal login cleanly via `az login --service-principal`.
+
+**Support both az CLI and PAT as fallback.** Rejected to keep the auth surface simple and auditable. A fallback chain obscures which credential is actually in use and re-introduces the secrets-in-files problem for anyone who configures a PAT "just in case".
+
+## Consequences
+
+- `az` must be installed and the user must be logged in (`az login`) for the Azure Boards backend to work. A clear, actionable error is returned if the command fails or produces no token.
+- `token_file` and `AZURE_DEVOPS_PAT` config fields are removed from the profile schema.
+- HTTP auth changes from Basic (`Authorization: Basic base64(:PAT)`) to Bearer (`Authorization: Bearer <access_token>`).
+- Tokens are short-lived (~1 hour); az CLI handles refresh transparently. No token caching is needed in Canopy.
+- Non-interactive environments (CI, cron) work via `az login --service-principal` — no Canopy-specific secret handling required.

--- a/docs/adr/ADR-003-tui-navigation-and-filtering.md
+++ b/docs/adr/ADR-003-tui-navigation-and-filtering.md
@@ -1,0 +1,36 @@
+# ADR-003: TUI navigation and filtering model
+
+**Status:** Accepted
+**Date:** 2026-04-22
+**Applies to:** `internal/app/`
+
+## Context
+
+The initial TUI had three tabs (My Tasks, Team, Views) with basic vim-style navigation (j/k/h/l/g/G) and no filtering. Task lists returned everything from the backend with no time scoping, causing the team tab to hit the 200-item WIQL cap with historical items. Closed tasks cluttered the active work views.
+
+A sibling project, grove (a GitHub repository monitor TUI), has a mature navigation model with cycle filters, per-tab state, and context-aware keybindings that users are already familiar with.
+
+## Decision
+
+Adopt grove's navigation and filtering patterns:
+
+**Tabs:** My Tasks, Team, Done, Views — with 1–4 direct-jump keys and h/l cycling. Active tabs (My Tasks, Team) exclude done/closed items by default. The Done tab shows only done/closed items. Views tab renders named filter presets from config.
+
+**Cycle filters:** pressing a filter key cycles through unique values from the current dataset, wrapping to clear. Keys: `f` (date: this week / last week / this month / last month / this quarter / clear), `d` (assignee), `s` (work item type). `/` opens text search.
+
+**Date scoping:** all tabs default to "this week" (`[System.ChangedDate] >= @today - 7`). The `f` cycle overrides this. This prevents unbounded queries from hitting the WIQL 200-item cap.
+
+**Navigation:** j/k cursor, gg/G first/last, o open-in-browser, r refresh, q/ctrl+c quit — matching grove exactly.
+
+## Alternatives Considered
+
+**Keep the original three-tab layout with Views as the filtering mechanism.** Rejected because closed tasks dominate the list and there's no quick way to scope by time without creating many views.
+
+**Add a filter bar with typed queries.** Rejected as over-engineered for the current use case. Cycle filters are faster for the small set of fields that matter (date, assignee, type).
+
+## Consequences
+
+- Users familiar with grove will be immediately productive in canopy.
+- Per-tab filter state must be tracked (date range, assignee, type, text query per tab).
+- The Views tab becomes less critical since cycle filters handle most ad-hoc filtering, but remains useful for meeting presets (standup, sprint review).
+- Default time scoping means the team tab no longer hits the 200-item cap in normal use.

--- a/docs/adr/ADR-004-task-drill-down-navigation.md
+++ b/docs/adr/ADR-004-task-drill-down-navigation.md
@@ -1,0 +1,38 @@
+# ADR-004: Task drill-down navigation
+
+**Status:** Accepted
+**Date:** 2026-04-23
+**Applies to:** `internal/app/update.go`, `internal/app/view.go`, `internal/app/model.go`
+
+## Context
+
+ADR-003 established the TUI navigation model with tabs, cycle filters, and vim-style cursor movement. However, tasks with parent-child relationships (epics > user stories > subtasks) could only be viewed in a flat list with a PARENT column. There was no way to navigate into a task to see its subtasks or move between sibling tasks without scrolling through the full list.
+
+The sibling project grove has a proven drill-down navigation pattern: Enter navigates into an item showing its children, Esc goes back, and `[`/`]` move between siblings. Users are already familiar with this pattern.
+
+## Decision
+
+Add a navigation stack (`navStack []model.Task`) that tracks the chain of parent tasks the user has drilled into:
+
+**Enter** pushes the selected task onto the stack. The view then shows only tasks whose `ParentID` matches that task's `ID`, searching across all loaded task lists (myTasks, teamTasks, doneTasks) with deduplication. A breadcrumb trail renders above the task list showing the full path (e.g. `My Tasks > Epic Title > Story Title`).
+
+**Esc** pops the stack (after clearing any active filters first). **Backspace** always pops immediately without the filter-clearing precedence.
+
+**`[` / `]`** replace the top of the stack with the previous/next sibling task. Siblings are computed from the grandparent level (or the tab's root list for depth-1 navigation). This works in both the main view and the detail overlay.
+
+**`i`** opens the detail overlay (previously bound to Enter). Inside the overlay, `[`/`]` move between tasks and `enter` drills into the displayed task.
+
+Tab switching (`h`/`l`/`1-4`) clears the navigation stack entirely.
+
+## Alternatives Considered
+
+**Filter-based approach (filter by ParentID).** Would reuse existing filter machinery but conflates navigation context with search filters. Pressing Esc would be ambiguous: does it clear the parent filter or the text search? A separate stack keeps navigation orthogonal to filtering.
+
+**Tree view with expand/collapse.** More traditional but harder to implement with the current flat-list rendering and would require significant view refactoring. The drill-down approach reuses the existing list renderer and matches grove's proven pattern.
+
+## Consequences
+
+- Users can explore task hierarchies by drilling into parent tasks and navigating between siblings.
+- The navigation stack is independent of filters — users can filter within a navigated level.
+- Child lookup is O(n) over all loaded tasks per render. This is acceptable for typical task counts (< 1000) but may need indexing if datasets grow significantly.
+- The detail overlay trigger moved from Enter to `i`, which is a keybinding change users need to learn.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,3 +1,5 @@
 | ADR | Title | Area |
 |---|---|---|
 | [ADR-001](ADR-001-backend-interface-abstraction.md) | Backend interface abstraction | architecture |
+| [ADR-002](ADR-002-azure-auth-via-az-cli.md) | Azure authentication via az CLI | auth |
+| [ADR-003](ADR-003-tui-navigation-and-filtering.md) | TUI navigation and filtering model | UX |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,3 +3,4 @@
 | [ADR-001](ADR-001-backend-interface-abstraction.md) | Backend interface abstraction | architecture |
 | [ADR-002](ADR-002-azure-auth-via-az-cli.md) | Azure authentication via az CLI | auth |
 | [ADR-003](ADR-003-tui-navigation-and-filtering.md) | TUI navigation and filtering model | UX |
+| [ADR-004](ADR-004-task-drill-down-navigation.md) | Task drill-down navigation | UX |

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,37 +16,65 @@ import (
 type tasksLoadedMsg struct {
 	myTasks   []model.Task
 	teamTasks []model.Task
+	doneTasks []model.Task
 	err       error
 }
 
 type tickMsg time.Time
+type ggTimeoutMsg struct{}
 
 // ── Commands ────────────────────────────────────────────────────────────
 
+// loadAllTasks fetches my tasks, team tasks (active only), and done tasks
+// using the current dateScope for time-bounding.
 func (m Model) loadAllTasks() tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		var myTasks, teamTasks []model.Task
+		days := dateScopeDays(m.dateScope)
+		scope := fmt.Sprintf("last_%d_days", days)
+
+		var myTasks, teamTasks, doneTasks []model.Task
 
 		for _, b := range m.backends {
-			// My tasks
-			my, err := b.ListTasks(ctx, config.Filter{Assignee: "me"})
+			// My active tasks (not done/closed)
+			my, err := b.ListTasks(ctx, config.Filter{
+				Assignee:     "me",
+				Status:       []string{"todo", "in-progress", "in-review"},
+				UpdatedSince: scope,
+			})
 			if err != nil {
 				return tasksLoadedMsg{err: err}
 			}
 			myTasks = append(myTasks, my...)
 
-			// Team tasks (no assignee filter — returns all)
-			all, err := b.ListTasks(ctx, config.Filter{})
+			// Team active tasks (not done/closed)
+			team, err := b.ListTasks(ctx, config.Filter{
+				Status:       []string{"todo", "in-progress", "in-review"},
+				UpdatedSince: scope,
+			})
 			if err != nil {
 				return tasksLoadedMsg{err: err}
 			}
-			teamTasks = append(teamTasks, all...)
+			teamTasks = append(teamTasks, team...)
+
+			// Done/closed tasks
+			done, err := b.ListTasks(ctx, config.Filter{
+				Status:       []string{"done", "closed"},
+				UpdatedSince: scope,
+			})
+			if err != nil {
+				return tasksLoadedMsg{err: err}
+			}
+			doneTasks = append(doneTasks, done...)
 		}
 
-		return tasksLoadedMsg{myTasks: myTasks, teamTasks: teamTasks}
+		return tasksLoadedMsg{
+			myTasks:   myTasks,
+			teamTasks: teamTasks,
+			doneTasks: doneTasks,
+		}
 	}
 }
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/alcxyz/canopy/internal/config"
+	"github.com/alcxyz/canopy/internal/model"
+)
+
+// ── Messages ────────────────────────────────────────────────────────────
+
+type tasksLoadedMsg struct {
+	myTasks   []model.Task
+	teamTasks []model.Task
+	err       error
+}
+
+type tickMsg time.Time
+
+// ── Commands ────────────────────────────────────────────────────────────
+
+func (m Model) loadAllTasks() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		var myTasks, teamTasks []model.Task
+
+		for _, b := range m.backends {
+			// My tasks
+			my, err := b.ListTasks(ctx, config.Filter{Assignee: "me"})
+			if err != nil {
+				return tasksLoadedMsg{err: err}
+			}
+			myTasks = append(myTasks, my...)
+
+			// Team tasks (no assignee filter — returns all)
+			all, err := b.ListTasks(ctx, config.Filter{})
+			if err != nil {
+				return tasksLoadedMsg{err: err}
+			}
+			teamTasks = append(teamTasks, all...)
+		}
+
+		return tasksLoadedMsg{myTasks: myTasks, teamTasks: teamTasks}
+	}
+}
+
+func (m Model) loadViewTasks(filter config.Filter) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		var tasks []model.Task
+		for _, b := range m.backends {
+			t, err := b.ListTasks(ctx, filter)
+			if err != nil {
+				return tasksLoadedMsg{err: err}
+			}
+			tasks = append(tasks, t...)
+		}
+
+		return tasksLoadedMsg{myTasks: tasks, teamTasks: tasks}
+	}
+}
+
+func tickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -22,6 +25,7 @@ type tasksLoadedMsg struct {
 
 type tickMsg time.Time
 type ggTimeoutMsg struct{}
+type versionCheckMsg struct{ latest string }
 
 // ── Commands ────────────────────────────────────────────────────────────
 
@@ -100,4 +104,58 @@ func tickCmd(d time.Duration) tea.Cmd {
 	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
+}
+
+// isSemver returns true when v looks like a release version (x.y.z).
+func isSemver(v string) bool {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// checkLatestVersion fetches the latest GitHub release tag in the background
+// and returns a versionCheckMsg if a newer version is available.
+// Silently no-ops for dev builds, hash builds, or when the network is unavailable.
+func checkLatestVersion(version string) tea.Cmd {
+	return func() tea.Msg {
+		if !isSemver(version) {
+			return versionCheckMsg{}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			"https://api.github.com/repos/alcxyz/canopy/releases/latest", nil)
+		if err != nil {
+			return versionCheckMsg{}
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("User-Agent", "canopy/"+version)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return versionCheckMsg{}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return versionCheckMsg{}
+		}
+		var payload struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return versionCheckMsg{}
+		}
+		if payload.TagName == "v"+version || payload.TagName == version {
+			return versionCheckMsg{}
+		}
+		return versionCheckMsg{latest: payload.TagName}
+	}
 }

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -9,7 +9,10 @@ import (
 )
 
 // timeBuckets are the fixed date-range labels for the f date-cycle filter.
-var timeBuckets = []string{"this week", "last week", "this month", "last month", "this quarter", "last quarter"}
+var timeBuckets = []string{"today", "yesterday", "this week", "last week", "this month", "last month", "this quarter", "last quarter", "last 6 months", "prior 6 months"}
+
+// dateFields are the available timestamp fields for the F date-field cycle.
+var dateFields = []string{"updated", "created", "start", "target", "closed", "state changed"}
 
 // dateInBucket returns true if t falls within the named time bucket.
 func dateInBucket(t time.Time, label string) bool {
@@ -50,6 +53,13 @@ func dateInBucket(t time.Time, label string) bool {
 		qStart := time.Date(y, ((mo-1)/3)*3+1, 1, 0, 0, 0, 0, loc)
 		lastQStart := qStart.AddDate(0, -3, 0)
 		return !t.Before(lastQStart) && t.Before(qStart)
+	case "last 6 months":
+		sixAgo := now.AddDate(0, -6, 0)
+		return !t.Before(sixAgo)
+	case "prior 6 months":
+		sixAgo := now.AddDate(0, -6, 0)
+		twelveAgo := now.AddDate(0, -12, 0)
+		return !t.Before(twelveAgo) && t.Before(sixAgo)
 	}
 	return false
 }
@@ -58,6 +68,10 @@ func dateInBucket(t time.Time, label string) bool {
 // query's updated_since filter. Returns 0 if no scoping should be applied.
 func dateScopeDays(scope string) int {
 	switch scope {
+	case "today":
+		return 1
+	case "yesterday":
+		return 2
 	case "this week":
 		return 7
 	case "last week":
@@ -70,6 +84,10 @@ func dateScopeDays(scope string) int {
 		return 90
 	case "last quarter":
 		return 180
+	case "last 6 months":
+		return 180
+	case "prior 6 months":
+		return 365
 	}
 	return 7 // default to a week
 }
@@ -88,7 +106,8 @@ func (m Model) filteredTasks(tasks []model.Task) []model.Task {
 				!strings.Contains(strings.ToLower(t.Assignee), q) &&
 				!strings.Contains(strings.ToLower(string(t.Type)), q) &&
 				!strings.Contains(strings.ToLower(t.ID), q) &&
-				!strings.Contains(strings.ToLower(t.Sprint), q) {
+				!strings.Contains(strings.ToLower(t.Sprint), q) &&
+				!labelsContain(t.Labels, q) {
 				continue
 			}
 		}
@@ -98,12 +117,39 @@ func (m Model) filteredTasks(tasks []model.Task) []model.Task {
 		if !m.cycleMatch("type", string(t.Type)) {
 			continue
 		}
-		if !m.cycleMatchDate(t.UpdatedAt) {
+		if !m.cycleMatchTag(t.Labels) {
+			continue
+		}
+		if !m.cycleMatchDate(t) {
 			continue
 		}
 		out = append(out, t)
 	}
 	return out
+}
+
+// labelsContain returns true if any label contains the query substring.
+func labelsContain(labels []string, q string) bool {
+	for _, l := range labels {
+		if strings.Contains(strings.ToLower(l), q) {
+			return true
+		}
+	}
+	return false
+}
+
+// cycleMatchTag returns true if any label matches the active tag cycle filter.
+func (m Model) cycleMatchTag(labels []string) bool {
+	if m.cycleField != "tag" || m.cycleIdx < 0 || m.cycleIdx >= len(m.cycleValues) {
+		return true
+	}
+	target := m.cycleValues[m.cycleIdx]
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
 }
 
 // cycleMatch returns true if item passes the active cycle filter for the given field.
@@ -114,12 +160,30 @@ func (m Model) cycleMatch(field, value string) bool {
 	return value == m.cycleValues[m.cycleIdx]
 }
 
-// cycleMatchDate returns true if t falls in the active date bucket when date cycling.
-func (m Model) cycleMatchDate(t time.Time) bool {
+// taskDateField returns the timestamp from t that corresponds to the active date field.
+func (m Model) taskDateField(t model.Task) time.Time {
+	switch m.dateField {
+	case "created":
+		return t.CreatedAt
+	case "start":
+		return t.StartDate
+	case "target":
+		return t.TargetDate
+	case "closed":
+		return t.ClosedAt
+	case "state changed":
+		return t.StateChangedAt
+	default: // "updated"
+		return t.UpdatedAt
+	}
+}
+
+// cycleMatchDate returns true if the task's active date field falls in the active date bucket.
+func (m Model) cycleMatchDate(t model.Task) bool {
 	if m.cycleField != "date" || m.cycleIdx < 0 || m.cycleIdx >= len(m.cycleValues) {
 		return true
 	}
-	return dateInBucket(t, m.cycleValues[m.cycleIdx])
+	return dateInBucket(m.taskDateField(t), m.cycleValues[m.cycleIdx])
 }
 
 // collectCycleValues gathers unique sorted values for a field from the
@@ -154,11 +218,18 @@ func (m Model) collectCycleValues(field string) []string {
 		seen[v] = struct{}{}
 		vals = append(vals, v)
 	}
+	// Seed with config preset tags so they always appear first.
+	if field == "tag" {
+		for _, t := range m.cfg.Tags {
+			add(t)
+		}
+	}
 	for _, t := range tasks {
 		if q != "" {
 			if !strings.Contains(strings.ToLower(t.Title), q) &&
 				!strings.Contains(strings.ToLower(t.Assignee), q) &&
-				!strings.Contains(strings.ToLower(string(t.Type)), q) {
+				!strings.Contains(strings.ToLower(string(t.Type)), q) &&
+				!labelsContain(t.Labels, q) {
 				continue
 			}
 		}
@@ -167,6 +238,10 @@ func (m Model) collectCycleValues(field string) []string {
 			add(t.Assignee)
 		case "type":
 			add(string(t.Type))
+		case "tag":
+			for _, l := range t.Labels {
+				add(l)
+			}
 		}
 	}
 	sort.Strings(vals)
@@ -203,6 +278,12 @@ func (m *Model) doCycleFilter(field string) {
 		m.cycleIdx = nextIdx
 	}
 	m.cursor = 0
+}
+
+// doCycleDateField advances the date field used by the f date-cycle filter.
+func (m *Model) doCycleDateField() {
+	m.dateFieldIdx = (m.dateFieldIdx + 1) % len(dateFields)
+	m.dateField = dateFields[m.dateFieldIdx]
 }
 
 // clearCycleFilter resets any active cycle filter.

--- a/internal/app/filter.go
+++ b/internal/app/filter.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/alcxyz/canopy/internal/model"
+)
+
+// timeBuckets are the fixed date-range labels for the f date-cycle filter.
+var timeBuckets = []string{"this week", "last week", "this month", "last month", "this quarter", "last quarter"}
+
+// dateInBucket returns true if t falls within the named time bucket.
+func dateInBucket(t time.Time, label string) bool {
+	if t.IsZero() {
+		return false
+	}
+	now := time.Now()
+	y, mo, d := now.Date()
+	loc := now.Location()
+	todayStart := time.Date(y, mo, d, 0, 0, 0, 0, loc)
+	switch label {
+	case "today":
+		return !t.Before(todayStart)
+	case "yesterday":
+		return !t.Before(todayStart.AddDate(0, 0, -1)) && t.Before(todayStart)
+	case "this week":
+		wd := int(now.Weekday())
+		if wd == 0 {
+			wd = 7
+		}
+		return !t.Before(todayStart.AddDate(0, 0, -(wd - 1)))
+	case "last week":
+		wd := int(now.Weekday())
+		if wd == 0 {
+			wd = 7
+		}
+		thisWeek := todayStart.AddDate(0, 0, -(wd - 1))
+		return !t.Before(thisWeek.AddDate(0, 0, -7)) && t.Before(thisWeek)
+	case "this month":
+		return !t.Before(time.Date(y, mo, 1, 0, 0, 0, 0, loc))
+	case "last month":
+		thisMonth := time.Date(y, mo, 1, 0, 0, 0, 0, loc)
+		return !t.Before(thisMonth.AddDate(0, -1, 0)) && t.Before(thisMonth)
+	case "this quarter":
+		qStart := time.Date(y, ((mo-1)/3)*3+1, 1, 0, 0, 0, 0, loc)
+		return !t.Before(qStart)
+	case "last quarter":
+		qStart := time.Date(y, ((mo-1)/3)*3+1, 1, 0, 0, 0, 0, loc)
+		lastQStart := qStart.AddDate(0, -3, 0)
+		return !t.Before(lastQStart) && t.Before(qStart)
+	}
+	return false
+}
+
+// dateScopeDays maps a dateScope label to a number of days for the backend
+// query's updated_since filter. Returns 0 if no scoping should be applied.
+func dateScopeDays(scope string) int {
+	switch scope {
+	case "this week":
+		return 7
+	case "last week":
+		return 14
+	case "this month":
+		return 30
+	case "last month":
+		return 60
+	case "this quarter":
+		return 90
+	case "last quarter":
+		return 180
+	}
+	return 7 // default to a week
+}
+
+// filteredTasks applies text search and cycle filters to a task slice.
+func (m Model) filteredTasks(tasks []model.Task) []model.Task {
+	q := strings.ToLower(m.filterQuery)
+	hasCycle := m.cycleField != "" && m.cycleIdx >= 0
+	if q == "" && !hasCycle {
+		return tasks
+	}
+	out := make([]model.Task, 0, len(tasks))
+	for _, t := range tasks {
+		if q != "" {
+			if !strings.Contains(strings.ToLower(t.Title), q) &&
+				!strings.Contains(strings.ToLower(t.Assignee), q) &&
+				!strings.Contains(strings.ToLower(string(t.Type)), q) &&
+				!strings.Contains(strings.ToLower(t.ID), q) &&
+				!strings.Contains(strings.ToLower(t.Sprint), q) {
+				continue
+			}
+		}
+		if !m.cycleMatch("assignee", t.Assignee) {
+			continue
+		}
+		if !m.cycleMatch("type", string(t.Type)) {
+			continue
+		}
+		if !m.cycleMatchDate(t.UpdatedAt) {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// cycleMatch returns true if item passes the active cycle filter for the given field.
+func (m Model) cycleMatch(field, value string) bool {
+	if m.cycleField != field || m.cycleIdx < 0 || m.cycleIdx >= len(m.cycleValues) {
+		return true
+	}
+	return value == m.cycleValues[m.cycleIdx]
+}
+
+// cycleMatchDate returns true if t falls in the active date bucket when date cycling.
+func (m Model) cycleMatchDate(t time.Time) bool {
+	if m.cycleField != "date" || m.cycleIdx < 0 || m.cycleIdx >= len(m.cycleValues) {
+		return true
+	}
+	return dateInBucket(t, m.cycleValues[m.cycleIdx])
+}
+
+// collectCycleValues gathers unique sorted values for a field from the
+// currently visible tasks on the active tab.
+func (m Model) collectCycleValues(field string) []string {
+	if field == "date" {
+		return timeBuckets
+	}
+	var tasks []model.Task
+	switch m.activeTab {
+	case tabMyTasks:
+		tasks = m.myTasks
+	case tabTeam:
+		tasks = m.teamTasks
+	case tabDone:
+		tasks = m.doneTasks
+	default:
+		return nil
+	}
+
+	// Apply text filter only (not cycle) so we collect values from the text-filtered set.
+	q := strings.ToLower(m.filterQuery)
+	seen := map[string]struct{}{}
+	var vals []string
+	add := func(v string) {
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		vals = append(vals, v)
+	}
+	for _, t := range tasks {
+		if q != "" {
+			if !strings.Contains(strings.ToLower(t.Title), q) &&
+				!strings.Contains(strings.ToLower(t.Assignee), q) &&
+				!strings.Contains(strings.ToLower(string(t.Type)), q) {
+				continue
+			}
+		}
+		switch field {
+		case "assignee":
+			add(t.Assignee)
+		case "type":
+			add(string(t.Type))
+		}
+	}
+	sort.Strings(vals)
+	return vals
+}
+
+// doCycleFilter advances (or starts) a cycle filter for field.
+func (m *Model) doCycleFilter(field string) {
+	newVals := m.collectCycleValues(field)
+	if len(newVals) == 0 {
+		return
+	}
+	if m.cycleField != field {
+		m.cycleField = field
+		m.cycleValues = newVals
+		m.cycleIdx = 0
+	} else {
+		currentVal := ""
+		if m.cycleIdx >= 0 && m.cycleIdx < len(m.cycleValues) {
+			currentVal = m.cycleValues[m.cycleIdx]
+		}
+		nextIdx := 0
+		for i, v := range newVals {
+			if v == currentVal {
+				nextIdx = i + 1
+				break
+			}
+		}
+		m.cycleValues = newVals
+		if nextIdx >= len(newVals) {
+			m.clearCycleFilter()
+			return
+		}
+		m.cycleIdx = nextIdx
+	}
+	m.cursor = 0
+}
+
+// clearCycleFilter resets any active cycle filter.
+func (m *Model) clearCycleFilter() {
+	m.cycleField = ""
+	m.cycleValues = nil
+	m.cycleIdx = -1
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -22,29 +22,39 @@ type Model struct {
 	backends []backend.Backend
 
 	// Data
-	tasks []model.Task
+	myTasks   []model.Task
+	teamTasks []model.Task
 
 	// UI state
 	activeTab     tab
 	activeProfile int // -1 = all
-	activeView    int
+	activeView    int // selected view index on Views tab
 	cursor        int
 	width, height int
 	ready         bool
+	loading       bool
+	err           error
+	statusMsg     string // transient status message
 }
 
 // New creates a new Model from the loaded config.
 func New(cfg config.Config) Model {
 	var backends []backend.Backend
+	var initErrs []string
 	for _, p := range cfg.Profiles {
 		b, err := backend.New(p)
 		if err != nil {
-			continue // skip misconfigured profiles
+			initErrs = append(initErrs, err.Error())
+			continue
 		}
 		backends = append(backends, b)
 	}
-	return Model{
+	m := Model{
 		cfg:      cfg,
 		backends: backends,
 	}
+	if len(initErrs) > 0 && len(backends) == 0 {
+		m.statusMsg = "Backend errors: " + initErrs[0]
+	}
+	return m
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"time"
+
 	"github.com/alcxyz/canopy/internal/backend"
 	"github.com/alcxyz/canopy/internal/config"
 	"github.com/alcxyz/canopy/internal/model"
@@ -11,37 +13,75 @@ type tab int
 const (
 	tabMyTasks tab = iota
 	tabTeam
+	tabDone
 	tabViews
 )
 
-var tabNames = []string{"My Tasks", "Team", "Views"}
+var tabNames = []string{"My Tasks [1]", "Team [2]", "Done [3]", "Views [4]"}
 
 // Model is the top-level bubbletea model.
 type Model struct {
 	cfg      config.Config
 	backends []backend.Backend
 
-	// Data
+	// Raw data from backends (unfiltered).
 	myTasks   []model.Task
 	teamTasks []model.Task
+	doneTasks []model.Task
 
 	// UI state
 	activeTab     tab
-	activeProfile int // -1 = all
 	activeView    int // selected view index on Views tab
 	cursor        int
 	width, height int
 	ready         bool
 	loading       bool
 	err           error
-	statusMsg     string // transient status message
+	statusMsg     string
+
+	// Vim-style gg navigation
+	prevKey    string
+	prevKeyAt  time.Time
+	ggTimeout  time.Duration
+
+	// Text filter (/ key)
+	filtering   bool
+	filterQuery string
+
+	// Cycle quick-filter (f=date, d=assignee, s=type)
+	cycleField  string
+	cycleValues []string
+	cycleIdx    int
+
+	// Date scope: the default time range applied to backend queries.
+	// Overridden by the f cycle filter for client-side filtering.
+	dateScope string // "this week" by default
+
+	// Overlays
+	showHelp   bool
+	showSplash bool
+
+	// Paths shown in splash
+	version  string
+	logPath  string
+	cfgPath  string
+	cacheDir string
+}
+
+// Options holds the parameters for creating a new Model.
+type Options struct {
+	Cfg      config.Config
+	Version  string
+	LogPath  string
+	CfgPath  string
+	CacheDir string
 }
 
 // New creates a new Model from the loaded config.
-func New(cfg config.Config) Model {
+func New(o Options) Model {
 	var backends []backend.Backend
 	var initErrs []string
-	for _, p := range cfg.Profiles {
+	for _, p := range o.Cfg.Profiles {
 		b, err := backend.New(p)
 		if err != nil {
 			initErrs = append(initErrs, err.Error())
@@ -50,8 +90,18 @@ func New(cfg config.Config) Model {
 		backends = append(backends, b)
 	}
 	m := Model{
-		cfg:      cfg,
-		backends: backends,
+		cfg:       o.Cfg,
+		backends:  backends,
+		cycleIdx:  -1,
+		ggTimeout: 400 * time.Millisecond,
+		dateScope: "this week",
+		version:   o.Version,
+		logPath:   o.LogPath,
+		cfgPath:   o.CfgPath,
+		cacheDir:  o.CacheDir,
+	}
+	if m.version == "" {
+		m.version = "dev"
 	}
 	if len(initErrs) > 0 && len(backends) == 0 {
 		m.statusMsg = "Backend errors: " + initErrs[0]

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/alcxyz/canopy/internal/backend"
+	"github.com/alcxyz/canopy/internal/cache"
 	"github.com/alcxyz/canopy/internal/config"
 	"github.com/alcxyz/canopy/internal/model"
 )
@@ -57,9 +59,25 @@ type Model struct {
 	// Overridden by the f cycle filter for client-side filtering.
 	dateScope string // "this week" by default
 
+	// Date field: which timestamp to use for the date cycle filter.
+	dateField    string   // current field label, e.g. "updated"
+	dateFieldIdx int      // index into dateFields
+
+	// Navigation stack for drilling into parent tasks.
+	navStack []model.Task
+
 	// Overlays
 	showHelp   bool
 	showSplash bool
+	showDetail bool
+	detailTask model.Task
+
+	// Cache
+	cache        *cache.Store
+	tasksLoadedAt time.Time // when the current data was fetched
+
+	// Version update check
+	latestVersion string // non-empty when a newer release is available
 
 	// Paths shown in splash
 	version  string
@@ -75,6 +93,11 @@ type Options struct {
 	LogPath  string
 	CfgPath  string
 	CacheDir string
+}
+
+// cachedTasks is the shape persisted in the cache files.
+type cachedTasks struct {
+	Tasks []model.Task `json:"tasks"`
 }
 
 // New creates a new Model from the loaded config.
@@ -106,5 +129,51 @@ func New(o Options) Model {
 	if len(initErrs) > 0 && len(backends) == 0 {
 		m.statusMsg = "Backend errors: " + initErrs[0]
 	}
+
+	// Initialise cache and load last-known data for instant startup.
+	if cs, err := cache.New(o.CacheDir, o.Cfg.CacheKey()); err == nil {
+		m.cache = cs
+		m.loadCachedTasks()
+	}
+
 	return m
+}
+
+// loadCachedTasks restores task lists from the on-disk cache.
+// No TTL is enforced here — stale data is shown immediately and replaced
+// by a background refresh.
+func (m *Model) loadCachedTasks() {
+	load := func(key string) []model.Task {
+		e, _ := m.cache.Get(key, 0)
+		if e == nil {
+			return nil
+		}
+		var ct cachedTasks
+		if err := json.Unmarshal(e.Data, &ct); err != nil {
+			return nil
+		}
+		return ct.Tasks
+	}
+	m.myTasks = load("my_tasks")
+	m.teamTasks = load("team_tasks")
+	m.doneTasks = load("done_tasks")
+	if len(m.myTasks)+len(m.teamTasks)+len(m.doneTasks) > 0 {
+		m.statusMsg = "showing cached data…"
+	}
+}
+
+// saveCachedTasks persists task lists to disk asynchronously.
+func (m Model) saveCachedTasks() {
+	if m.cache == nil {
+		return
+	}
+	cs := m.cache
+	my := m.myTasks
+	team := m.teamTasks
+	done := m.doneTasks
+	go func() {
+		_ = cs.Set("my_tasks", cachedTasks{Tasks: my})
+		_ = cs.Set("team_tasks", cachedTasks{Tasks: team})
+		_ = cs.Set("done_tasks", cachedTasks{Tasks: done})
+	}()
 }

--- a/internal/app/open.go
+++ b/internal/app/open.go
@@ -1,0 +1,19 @@
+package app
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+func openURL(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}

--- a/internal/app/open.go
+++ b/internal/app/open.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 func openURL(url string) {
@@ -16,4 +17,23 @@ func openURL(url string) {
 		cmd = exec.Command("xdg-open", url)
 	}
 	_ = cmd.Start()
+}
+
+func copyToClipboard(s string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "windows":
+		cmd = exec.Command("clip")
+	default:
+		// Try wl-copy (Wayland) first, fall back to xclip.
+		if _, err := exec.LookPath("wl-copy"); err == nil {
+			cmd = exec.Command("wl-copy")
+		} else {
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		}
+	}
+	cmd.Stdin = strings.NewReader(s)
+	_ = cmd.Run()
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -21,8 +21,26 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
+	// Overlays intercept keys first.
+	if m.showHelp {
+		if km, ok := msg.(tea.KeyMsg); ok {
+			return m.handleHelpKey(km)
+		}
+	}
+	if m.showSplash {
+		if km, ok := msg.(tea.KeyMsg); ok {
+			return m.handleSplashKey(km)
+		}
+	}
 
+	// In text-filter mode, handle input first.
+	if m.filtering {
+		if km, ok := msg.(tea.KeyMsg); ok {
+			return m.handleFilterKey(km)
+		}
+	}
+
+	switch msg := msg.(type) {
 	case tasksLoadedMsg:
 		m.loading = false
 		if msg.err != nil {
@@ -30,9 +48,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = fmt.Sprintf("Error: %v", msg.err)
 		} else {
 			m.err = nil
-			m.statusMsg = ""
 			m.myTasks = msg.myTasks
 			m.teamTasks = msg.teamTasks
+			m.doneTasks = msg.doneTasks
+			m.statusMsg = fmt.Sprintf("%d my · %d team · %d done",
+				len(m.myTasks), len(m.teamTasks), len(m.doneTasks))
 		}
 		return m, nil
 
@@ -43,6 +63,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tickCmd(time.Duration(m.cfg.RefreshSecs)*time.Second),
 			)
 		}
+		return m, nil
+
+	case ggTimeoutMsg:
+		m.prevKey = ""
 		return m, nil
 
 	case tea.WindowSizeMsg:
@@ -59,44 +83,109 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	key := msg.String()
+
+	// gg — go to first item (vim-style double-g with timeout)
+	if key == "g" {
+		if m.prevKey == "g" && time.Since(m.prevKeyAt) < m.ggTimeout {
+			m.cursor = 0
+			m.prevKey = ""
+			return m, nil
+		}
+		m.prevKey = "g"
+		m.prevKeyAt = time.Now()
+		return m, tea.Tick(m.ggTimeout, func(time.Time) tea.Msg { return ggTimeoutMsg{} })
+	}
+	m.prevKey = ""
+
+	switch key {
 	case "q", "ctrl+c":
 		return m, tea.Quit
+
+	// Overlays
+	case "?":
+		m.showHelp = true
+		return m, nil
+	case "!":
+		m.showSplash = true
+		return m, nil
 
 	// Tab navigation
 	case "h":
 		if m.activeTab > 0 {
 			m.activeTab--
 			m.cursor = 0
+			m.clearCycleFilter()
+			m.filterQuery = ""
 		}
 	case "l":
 		if m.activeTab < tabViews {
 			m.activeTab++
 			m.cursor = 0
+			m.clearCycleFilter()
+			m.filterQuery = ""
 		}
 	case "1":
 		m.activeTab = tabMyTasks
 		m.cursor = 0
+		m.clearCycleFilter()
+		m.filterQuery = ""
 	case "2":
 		m.activeTab = tabTeam
 		m.cursor = 0
+		m.clearCycleFilter()
+		m.filterQuery = ""
 	case "3":
+		m.activeTab = tabDone
+		m.cursor = 0
+		m.clearCycleFilter()
+		m.filterQuery = ""
+	case "4":
 		m.activeTab = tabViews
 		m.cursor = 0
+		m.clearCycleFilter()
+		m.filterQuery = ""
 
 	// List navigation
-	case "j":
+	case "j", "down":
 		m.cursor++
 		m.clampCursor()
-	case "k":
+	case "k", "up":
 		if m.cursor > 0 {
 			m.cursor--
 		}
-	case "g":
-		m.cursor = 0
 	case "G":
 		m.cursor = m.listLen() - 1
 		if m.cursor < 0 {
+			m.cursor = 0
+		}
+
+	// Cycle filters
+	case "f":
+		if m.activeTab != tabViews {
+			m.doCycleFilter("date")
+		}
+	case "d":
+		if m.activeTab != tabViews {
+			m.doCycleFilter("assignee")
+		}
+	case "s":
+		if m.activeTab != tabViews {
+			m.doCycleFilter("type")
+		}
+
+	// Text search
+	case "/":
+		if m.activeTab != tabViews {
+			m.filtering = true
+			m.filterQuery = ""
+		}
+
+	// Clear filters
+	case "esc":
+		if m.cycleField != "" || m.filterQuery != "" {
+			m.clearCycleFilter()
+			m.filterQuery = ""
 			m.cursor = 0
 		}
 
@@ -121,6 +210,51 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "?", "esc", "q":
+		m.showHelp = false
+	}
+	return m, nil
+}
+
+func (m Model) handleSplashKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "!", "esc", "q":
+		m.showSplash = false
+	default:
+		m.showSplash = false
+	}
+	return m, nil
+}
+
+func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.filtering = false
+		m.filterQuery = ""
+		m.cursor = 0
+		return m, nil
+	case "enter":
+		m.filtering = false
+		m.cursor = 0
+		return m, nil
+	case "backspace":
+		if len(m.filterQuery) > 0 {
+			m.filterQuery = m.filterQuery[:len(m.filterQuery)-1]
+			m.cursor = 0
+		}
+		return m, nil
+	default:
+		r := msg.Runes
+		if len(r) > 0 {
+			m.filterQuery += string(r)
+			m.cursor = 0
+		}
+		return m, nil
+	}
+}
+
 func (m *Model) clampCursor() {
 	max := m.listLen() - 1
 	if max < 0 {
@@ -134,9 +268,11 @@ func (m *Model) clampCursor() {
 func (m Model) listLen() int {
 	switch m.activeTab {
 	case tabMyTasks:
-		return len(m.myTasks)
+		return len(m.filteredTasks(m.myTasks))
 	case tabTeam:
-		return len(m.teamTasks)
+		return len(m.filteredTasks(m.teamTasks))
+	case tabDone:
+		return len(m.filteredTasks(m.doneTasks))
 	case tabViews:
 		return len(m.cfg.Views)
 	}
@@ -147,9 +283,11 @@ func (m Model) openInBrowser() {
 	var tasks []model.Task
 	switch m.activeTab {
 	case tabMyTasks:
-		tasks = m.myTasks
+		tasks = m.filteredTasks(m.myTasks)
 	case tabTeam:
-		tasks = m.teamTasks
+		tasks = m.filteredTasks(m.teamTasks)
+	case tabDone:
+		tasks = m.filteredTasks(m.doneTasks)
 	default:
 		return
 	}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -17,6 +17,7 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		m.loadAllTasks(),
 		tickCmd(time.Duration(m.cfg.RefreshSecs)*time.Second),
+		checkLatestVersion(m.version),
 	)
 }
 
@@ -30,6 +31,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.showSplash {
 		if km, ok := msg.(tea.KeyMsg); ok {
 			return m.handleSplashKey(km)
+		}
+	}
+	if m.showDetail {
+		if km, ok := msg.(tea.KeyMsg); ok {
+			return m.handleDetailKey(km)
 		}
 	}
 
@@ -51,8 +57,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.myTasks = msg.myTasks
 			m.teamTasks = msg.teamTasks
 			m.doneTasks = msg.doneTasks
+			m.tasksLoadedAt = time.Now()
 			m.statusMsg = fmt.Sprintf("%d my · %d team · %d done",
 				len(m.myTasks), len(m.teamTasks), len(m.doneTasks))
+			m.saveCachedTasks()
 		}
 		return m, nil
 
@@ -63,6 +71,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tickCmd(time.Duration(m.cfg.RefreshSecs)*time.Second),
 			)
 		}
+		return m, nil
+
+	case versionCheckMsg:
+		m.latestVersion = msg.latest
 		return m, nil
 
 	case ggTimeoutMsg:
@@ -115,6 +127,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.activeTab > 0 {
 			m.activeTab--
 			m.cursor = 0
+			m.navStack = nil
 			m.clearCycleFilter()
 			m.filterQuery = ""
 		}
@@ -122,27 +135,32 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.activeTab < tabViews {
 			m.activeTab++
 			m.cursor = 0
+			m.navStack = nil
 			m.clearCycleFilter()
 			m.filterQuery = ""
 		}
 	case "1":
 		m.activeTab = tabMyTasks
 		m.cursor = 0
+		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
 	case "2":
 		m.activeTab = tabTeam
 		m.cursor = 0
+		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
 	case "3":
 		m.activeTab = tabDone
 		m.cursor = 0
+		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
 	case "4":
 		m.activeTab = tabViews
 		m.cursor = 0
+		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
 
@@ -165,6 +183,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.activeTab != tabViews {
 			m.doCycleFilter("date")
 		}
+	case "F":
+		if m.activeTab != tabViews {
+			m.doCycleDateField()
+		}
 	case "d":
 		if m.activeTab != tabViews {
 			m.doCycleFilter("assignee")
@@ -172,6 +194,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "s":
 		if m.activeTab != tabViews {
 			m.doCycleFilter("type")
+		}
+	case "t":
+		if m.activeTab != tabViews {
+			m.doCycleFilter("tag")
 		}
 
 	// Text search
@@ -181,11 +207,19 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterQuery = ""
 		}
 
-	// Clear filters
+	// Clear filters / navigate back
 	case "esc":
 		if m.cycleField != "" || m.filterQuery != "" {
 			m.clearCycleFilter()
 			m.filterQuery = ""
+			m.cursor = 0
+		} else if len(m.navStack) > 0 {
+			m.navStack = m.navStack[:len(m.navStack)-1]
+			m.cursor = 0
+		}
+	case "backspace":
+		if len(m.navStack) > 0 {
+			m.navStack = m.navStack[:len(m.navStack)-1]
 			m.cursor = 0
 		}
 
@@ -203,8 +237,30 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.statusMsg = fmt.Sprintf("Loading %s...", v.Name)
 			return m, m.loadViewTasks(v.Filters)
 		}
+		if t, ok := m.taskAtCursor(); ok {
+			m.navStack = append(m.navStack, t)
+			m.cursor = 0
+		}
+	case "i":
+		if t, ok := m.taskAtCursor(); ok {
+			m.showDetail = true
+			m.detailTask = t
+		}
+	case " ":
+		if t, ok := m.taskAtCursor(); ok && t.URL != "" {
+			copyToClipboard(t.URL)
+			m.statusMsg = "copied URL to clipboard"
+		}
 	case "o":
 		m.openInBrowser()
+	case "[":
+		if len(m.navStack) > 0 {
+			m.navigateSibling(-1)
+		}
+	case "]":
+		if len(m.navStack) > 0 {
+			m.navigateSibling(1)
+		}
 	}
 
 	return m, nil
@@ -224,6 +280,41 @@ func (m Model) handleSplashKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.showSplash = false
 	default:
 		m.showSplash = false
+	}
+	return m, nil
+}
+
+func (m Model) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q":
+		m.showDetail = false
+	case "enter":
+		m.showDetail = false
+		m.navStack = append(m.navStack, m.detailTask)
+		m.cursor = 0
+	case "[":
+		if m.cursor > 0 {
+			m.cursor--
+			if t, ok := m.taskAtCursor(); ok {
+				m.detailTask = t
+			}
+		}
+	case "]":
+		tasks := m.currentTasks()
+		if m.cursor < len(tasks)-1 {
+			m.cursor++
+			m.detailTask = tasks[m.cursor]
+		}
+	case "o":
+		if m.detailTask.URL != "" {
+			openURL(m.detailTask.URL)
+		}
+	case " ":
+		if m.detailTask.URL != "" {
+			copyToClipboard(m.detailTask.URL)
+			m.statusMsg = "copied URL to clipboard"
+			m.showDetail = false
+		}
 	}
 	return m, nil
 }
@@ -266,37 +357,107 @@ func (m *Model) clampCursor() {
 }
 
 func (m Model) listLen() int {
-	switch m.activeTab {
-	case tabMyTasks:
-		return len(m.filteredTasks(m.myTasks))
-	case tabTeam:
-		return len(m.filteredTasks(m.teamTasks))
-	case tabDone:
-		return len(m.filteredTasks(m.doneTasks))
-	case tabViews:
+	if m.activeTab == tabViews {
 		return len(m.cfg.Views)
 	}
-	return 0
+	return len(m.currentTasks())
+}
+
+func (m Model) taskAtCursor() (model.Task, bool) {
+	if m.activeTab == tabViews {
+		return model.Task{}, false
+	}
+	tasks := m.currentTasks()
+	if m.cursor >= len(tasks) {
+		return model.Task{}, false
+	}
+	return tasks[m.cursor], true
 }
 
 func (m Model) openInBrowser() {
-	var tasks []model.Task
+	if t, ok := m.taskAtCursor(); ok && t.URL != "" {
+		openURL(t.URL)
+	}
+}
+
+// currentTasks returns the task list for the active tab, filtered by the
+// current navigation stack (children of the deepest parent) and any active
+// text/cycle filters.
+func (m Model) currentTasks() []model.Task {
+	if len(m.navStack) > 0 {
+		parent := m.navStack[len(m.navStack)-1]
+		return m.filteredTasks(m.childTasks(parent.ID))
+	}
 	switch m.activeTab {
 	case tabMyTasks:
-		tasks = m.filteredTasks(m.myTasks)
+		return m.filteredTasks(m.myTasks)
 	case tabTeam:
-		tasks = m.filteredTasks(m.teamTasks)
+		return m.filteredTasks(m.teamTasks)
 	case tabDone:
-		tasks = m.filteredTasks(m.doneTasks)
-	default:
+		return m.filteredTasks(m.doneTasks)
+	}
+	return nil
+}
+
+// childTasks returns all loaded tasks whose ParentID matches the given ID,
+// deduplicated across all three task lists.
+func (m Model) childTasks(parentID string) []model.Task {
+	seen := make(map[string]bool)
+	var children []model.Task
+	for _, list := range [][]model.Task{m.myTasks, m.teamTasks, m.doneTasks} {
+		for _, t := range list {
+			if t.ParentID == parentID && !seen[t.ID] {
+				seen[t.ID] = true
+				children = append(children, t)
+			}
+		}
+	}
+	return children
+}
+
+// siblingTasks returns the task list at the same level as the top of the
+// navStack — i.e. the list the current parent was selected from.
+func (m Model) siblingTasks() []model.Task {
+	if len(m.navStack) > 1 {
+		grandparent := m.navStack[len(m.navStack)-2]
+		return m.filteredTasks(m.childTasks(grandparent.ID))
+	}
+	switch m.activeTab {
+	case tabMyTasks:
+		return m.filteredTasks(m.myTasks)
+	case tabTeam:
+		return m.filteredTasks(m.teamTasks)
+	case tabDone:
+		return m.filteredTasks(m.doneTasks)
+	}
+	return nil
+}
+
+// navigateSibling replaces the top of the navStack with the previous or next
+// sibling task (delta = -1 or +1).
+func (m *Model) navigateSibling(delta int) {
+	if len(m.navStack) == 0 {
 		return
 	}
-	if m.cursor >= len(tasks) {
+	siblings := m.siblingTasks()
+	current := m.navStack[len(m.navStack)-1]
+
+	idx := -1
+	for i, t := range siblings {
+		if t.ID == current.ID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
 		return
 	}
-	url := tasks[m.cursor].URL
-	if url == "" {
+
+	newIdx := idx + delta
+	if newIdx < 0 || newIdx >= len(siblings) {
 		return
 	}
-	openURL(url)
+
+	m.navStack[len(m.navStack)-1] = siblings[newIdx]
+	m.cursor = 0
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1,51 +1,121 @@
 package app
 
 import (
+	"fmt"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/alcxyz/canopy/internal/model"
 )
 
 func (m Model) Init() tea.Cmd {
-	return nil
+	if len(m.backends) == 0 {
+		return nil
+	}
+	m.loading = true
+	return tea.Batch(
+		m.loadAllTasks(),
+		tickCmd(time.Duration(m.cfg.RefreshSecs)*time.Second),
+	)
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			return m, tea.Quit
-		case "h":
-			if m.activeTab > 0 {
-				m.activeTab--
-				m.cursor = 0
-			}
-		case "l":
-			if m.activeTab < tabViews {
-				m.activeTab++
-				m.cursor = 0
-			}
-		case "j":
-			m.cursor++
-			m.clampCursor()
-		case "k":
-			if m.cursor > 0 {
-				m.cursor--
-			}
-		case "1":
-			m.activeTab = tabMyTasks
-			m.cursor = 0
-		case "2":
-			m.activeTab = tabTeam
-			m.cursor = 0
-		case "3":
-			m.activeTab = tabViews
-			m.cursor = 0
+
+	case tasksLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			m.statusMsg = fmt.Sprintf("Error: %v", msg.err)
+		} else {
+			m.err = nil
+			m.statusMsg = ""
+			m.myTasks = msg.myTasks
+			m.teamTasks = msg.teamTasks
 		}
+		return m, nil
+
+	case tickMsg:
+		if len(m.backends) > 0 {
+			return m, tea.Batch(
+				m.loadAllTasks(),
+				tickCmd(time.Duration(m.cfg.RefreshSecs)*time.Second),
+			)
+		}
+		return m, nil
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ready = true
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+
+	// Tab navigation
+	case "h":
+		if m.activeTab > 0 {
+			m.activeTab--
+			m.cursor = 0
+		}
+	case "l":
+		if m.activeTab < tabViews {
+			m.activeTab++
+			m.cursor = 0
+		}
+	case "1":
+		m.activeTab = tabMyTasks
+		m.cursor = 0
+	case "2":
+		m.activeTab = tabTeam
+		m.cursor = 0
+	case "3":
+		m.activeTab = tabViews
+		m.cursor = 0
+
+	// List navigation
+	case "j":
+		m.cursor++
+		m.clampCursor()
+	case "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "g":
+		m.cursor = 0
+	case "G":
+		m.cursor = m.listLen() - 1
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+
+	// Actions
+	case "r":
+		if len(m.backends) > 0 {
+			m.loading = true
+			m.statusMsg = "Refreshing..."
+			return m, m.loadAllTasks()
+		}
+	case "enter":
+		if m.activeTab == tabViews && m.cursor < len(m.cfg.Views) {
+			v := m.cfg.Views[m.cursor]
+			m.loading = true
+			m.statusMsg = fmt.Sprintf("Loading %s...", v.Name)
+			return m, m.loadViewTasks(v.Filters)
+		}
+	case "o":
+		m.openInBrowser()
 	}
 
 	return m, nil
@@ -63,10 +133,32 @@ func (m *Model) clampCursor() {
 
 func (m Model) listLen() int {
 	switch m.activeTab {
-	case tabMyTasks, tabTeam:
-		return len(m.tasks)
+	case tabMyTasks:
+		return len(m.myTasks)
+	case tabTeam:
+		return len(m.teamTasks)
 	case tabViews:
 		return len(m.cfg.Views)
 	}
 	return 0
+}
+
+func (m Model) openInBrowser() {
+	var tasks []model.Task
+	switch m.activeTab {
+	case tabMyTasks:
+		tasks = m.myTasks
+	case tabTeam:
+		tasks = m.teamTasks
+	default:
+		return
+	}
+	if m.cursor >= len(tasks) {
+		return
+	}
+	url := tasks[m.cursor].URL
+	if url == "" {
+		return
+	}
+	openURL(url)
 }

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -29,6 +29,14 @@ var (
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#585b70")).
 			Padding(1, 2)
+
+	// Indicator styles (grove pattern)
+	overdueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f38ba8")) // red
+	dueSoonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")) // yellow
+	freshStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")) // green
+	recentStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")) // blue
+	agingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")) // yellow
+	staleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#f38ba8")) // red
 )
 
 func (m Model) View() string {
@@ -42,6 +50,9 @@ func (m Model) View() string {
 	}
 	if m.showSplash {
 		return m.renderSplash()
+	}
+	if m.showDetail {
+		return m.renderDetail()
 	}
 
 	var b strings.Builder
@@ -64,6 +75,18 @@ func (m Model) View() string {
 	}
 
 	b.WriteString("\n")
+
+	// Breadcrumb (when navigated into a task)
+	if len(m.navStack) > 0 {
+		tabName := strings.SplitN(tabNames[m.activeTab], " [", 2)[0]
+		crumbs := []string{dimStyle.Render(tabName)}
+		for _, t := range m.navStack {
+			crumbs = append(crumbs, titleStyle.Render(truncate(t.Title, 40)))
+		}
+		b.WriteString("  " + strings.Join(crumbs, dimStyle.Render(" › ")))
+		b.WriteString("\n")
+	}
+
 	b.WriteString(strings.Repeat("─", m.width))
 	b.WriteString("\n")
 
@@ -75,12 +98,8 @@ func (m Model) View() string {
 
 	// Content
 	switch m.activeTab {
-	case tabMyTasks:
-		b.WriteString(m.renderTaskList(m.filteredTasks(m.myTasks)))
-	case tabTeam:
-		b.WriteString(m.renderTaskList(m.filteredTasks(m.teamTasks)))
-	case tabDone:
-		b.WriteString(m.renderTaskList(m.filteredTasks(m.doneTasks)))
+	case tabMyTasks, tabTeam, tabDone:
+		b.WriteString(m.renderTaskList(m.currentTasks()))
 	case tabViews:
 		b.WriteString(m.renderViews())
 	}
@@ -139,25 +158,35 @@ func (m Model) infoBarText() string {
 
 	// Tab-specific counts
 	switch m.activeTab {
-	case tabMyTasks:
-		n := len(m.filteredTasks(m.myTasks))
-		parts = append(parts, fmt.Sprintf("%d tasks", n))
-	case tabTeam:
-		n := len(m.filteredTasks(m.teamTasks))
-		parts = append(parts, fmt.Sprintf("%d tasks", n))
-	case tabDone:
-		n := len(m.filteredTasks(m.doneTasks))
-		parts = append(parts, fmt.Sprintf("%d tasks", n))
+	case tabMyTasks, tabTeam, tabDone:
+		n := len(m.currentTasks())
+		label := "tasks"
+		if len(m.navStack) > 0 {
+			label = "subtasks"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", n, label))
 	case tabViews:
 		parts = append(parts, fmt.Sprintf("%d views", len(m.cfg.Views)))
 	}
 
-	// Date scope
-	parts = append(parts, m.dateScope)
+	// Navigation hint
+	if len(m.navStack) > 0 {
+		parts = append(parts, "[/] sibling · esc back")
+	}
+
+	// Date scope and active field
+	dateLabel := m.dateScope
+	if m.dateField != "" && m.dateField != "updated" {
+		dateLabel += " (" + m.dateField + ")"
+	}
+	parts = append(parts, dateLabel)
 
 	// Hints
 	parts = append(parts, "? help")
 	parts = append(parts, "v"+m.version)
+	if m.latestVersion != "" {
+		parts = append(parts, "↑ "+m.latestVersion+" available")
+	}
 
 	return strings.Join(parts, " · ")
 }
@@ -189,18 +218,28 @@ func (m Model) renderHelp() string {
 
 Filters:
   /                        text search · esc clear
-  f                        cycle date (this week → last week → month → quarter)
+  f                        cycle date (today → yesterday → week → month → quarter → 6mo)
+  F                        cycle date field (updated → created → start → target → closed)
   d                        cycle by assignee
   s                        cycle by type (feature, bug, user-story…)
+  t                        cycle by tag / label
   esc                      clear all filters
 
 Actions:
+  enter                    navigate into task (show subtasks) · select view
+  esc / backspace          navigate back · clear filters
+  [ / ]                    prev / next sibling task
+  i                        task detail overlay
+  space                    copy task URL to clipboard
   o                        open task in browser
   r                        refresh data
-  enter                    select view (Views tab)
   !                        about / paths
   ?                        this help
-  q / ctrl+c               quit`
+  q / ctrl+c               quit
+
+Indicators:
+  ⏱  due        ! overdue · ● due this week · ○ has date · — no date
+  ↻  activity   ● green today · ● blue this week · ● yellow this month · ● red stale`
 
 	box := borderStyle.Width(min(72, m.width-4)).Render(
 		titleStyle.Render("canopy — help") + "\n\n" + help + "\n\n" +
@@ -236,6 +275,59 @@ func (m Model) renderSplash() string {
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
+// ── Task detail overlay ─────────────────────────────────────────────────
+
+func (m Model) renderDetail() string {
+	t := m.detailTask
+	w := min(80, m.width-4)
+
+	row := func(label, value string) string {
+		if value == "" {
+			value = dimStyle.Render("—")
+		}
+		return fmt.Sprintf("  %-16s %s\n", dimStyle.Render(label), value)
+	}
+
+	ss := stateColors[t.State]
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("  "+t.Title) + "\n\n")
+	b.WriteString(row("ID", t.ID))
+	b.WriteString(row("State", ss.Render(string(t.State))))
+	b.WriteString(row("Type", string(t.Type)))
+	b.WriteString(row("Assignee", t.Assignee))
+	b.WriteString(row("Sprint", t.Sprint))
+	b.WriteString(row("Parent", t.ParentTitle))
+	if len(t.Labels) > 0 {
+		b.WriteString(row("Tags", strings.Join(t.Labels, ", ")))
+	} else {
+		b.WriteString(row("Tags", ""))
+	}
+	b.WriteString("\n")
+	b.WriteString(row("Created", fmtTime(t.CreatedAt)))
+	b.WriteString(row("Updated", fmtTime(t.UpdatedAt)))
+	b.WriteString(row("Start date", fmtTime(t.StartDate)))
+	b.WriteString(row("Target date", fmtTime(t.TargetDate)))
+	b.WriteString(row("Closed", fmtTime(t.ClosedAt)))
+	b.WriteString(row("State changed", fmtTime(t.StateChangedAt)))
+	if t.URL != "" {
+		b.WriteString("\n")
+		b.WriteString(row("URL", dimStyle.Render(t.URL)))
+	}
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("  [/] prev/next · enter navigate in · o open · space copy URL · esc close"))
+
+	box := borderStyle.Width(w).Render(b.String())
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+func fmtTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02 15:04") + dimStyle.Render(" ("+timeAgo(t)+")")
+}
+
 // ── Task list rendering ─────────────────────────────────────────────────
 
 func (m Model) renderTaskList(tasks []model.Task) string {
@@ -246,21 +338,37 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 		if m.err != nil {
 			return dimStyle.Render(fmt.Sprintf("  Error: %v", m.err))
 		}
+		if len(m.navStack) > 0 {
+			return dimStyle.Render("  No subtasks.")
+		}
 		return dimStyle.Render("  No tasks found.")
 	}
 
 	var b strings.Builder
 
-	// Header — grove pattern: primary content first, metadata last (dimmed)
-	// TITLE(flex) PARENT(20) STATE(12) TYPE(12) ASSIGNEE(16) UPDATED(7) CREATED(7)
-	metaWidth := 20 + 12 + 12 + 16 + 7 + 7 // 74
-	titleWidth := m.width - metaWidth - 3   // 2 prefix + 1 space
-	if titleWidth < 16 {
-		titleWidth = 16
+	// Header — indicators, then flex columns (title+parent), then fixed metadata.
+	// Each column is separated by a single space for readability.
+	// DUE(2) ACT(2) TITLE(flex 60%) PARENT(flex 40%) STATE(12) TYPE(12) ASSIGNEE(18) UPDATED(7) CREATED(7)
+	const sep = " "
+	fixedWidth := 2 + 2 + 12 + 12 + 18 + 7 + 7 // 60 (column widths)
+	separators := 6                               // spaces between 7 columns (parent..created)
+	flexWidth := m.width - fixedWidth - separators - 2 // 2 for prefix
+	if flexWidth < 30 {
+		flexWidth = 30
 	}
+	titleWidth := flexWidth * 3 / 5   // 60%
+	parentWidth := flexWidth - titleWidth // 40%
 
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-*s %-20s %-12s %-12s %-16s %-7s %-7s",
-		titleWidth, "TITLE", "PARENT", "STATE", "TYPE", "ASSIGNEE", "UPDATED", "CREATED")))
+	hdr := "  " +
+		cell("!", 2) + cell("~", 2) +
+		cell("TITLE", titleWidth) + sep +
+		cell("PARENT", parentWidth) + sep +
+		cell("STATE", 12) + sep +
+		cell("TYPE", 12) + sep +
+		cell("ASSIGNEE", 18) + sep +
+		cell("UPDATED", 7) + sep +
+		cell("CREATED", 7)
+	b.WriteString(dimStyle.Render(hdr))
 	b.WriteString("\n")
 
 	for i, t := range tasks {
@@ -269,16 +377,20 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 			prefix = "> "
 		}
 
+		due := cell(dueIndicator(t), 2)
+		act := cell(activityIndicator(t), 2)
 		title := cell(truncate(t.Title, titleWidth), titleWidth)
-		parent := dimStyle.Render(cell(truncate(t.ParentTitle, 20), 20))
+		parent := dimStyle.Render(cell(truncate(t.ParentTitle, parentWidth), parentWidth))
 		ss := stateColors[t.State]
 		state := ss.Render(cell(string(t.State), 12))
 		typ := typeStyle.Render(cell(string(t.Type), 12))
-		assignee := dimStyle.Render(cell(truncate(t.Assignee, 16), 16))
+		assignee := dimStyle.Render(cell(truncate(t.Assignee, 18), 18))
 		updated := dimStyle.Render(cell(timeAgo(t.UpdatedAt), 7))
 		created := dimStyle.Render(cell(timeAgo(t.CreatedAt), 7))
 
-		line := fmt.Sprintf("%s%s %s%s%s%s%s%s", prefix, title, parent, state, typ, assignee, updated, created)
+		line := prefix + due + act + title + sep +
+			parent + sep + state + sep + typ + sep +
+			assignee + sep + updated + sep + created
 		if i == m.cursor {
 			line = selRow(line)
 		}
@@ -312,6 +424,41 @@ func (m Model) renderViews() string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// ── Indicator columns ──────────────────────────────────────────────────
+
+// dueIndicator shows target-date urgency: ! overdue, ● due this week, ○ has date.
+func dueIndicator(t model.Task) string {
+	if t.TargetDate.IsZero() {
+		return dimStyle.Render("—")
+	}
+	now := time.Now()
+	if t.TargetDate.Before(now) && t.State != model.StateDone && t.State != model.StateClosed {
+		return overdueStyle.Render("!")
+	}
+	if t.TargetDate.Before(now.AddDate(0, 0, 7)) {
+		return dueSoonStyle.Render("●")
+	}
+	return dimStyle.Render("○")
+}
+
+// activityIndicator shows freshness based on last update: ● green/blue/yellow/red.
+func activityIndicator(t model.Task) string {
+	if t.UpdatedAt.IsZero() {
+		return dimStyle.Render("—")
+	}
+	d := time.Since(t.UpdatedAt)
+	switch {
+	case d < 24*time.Hour:
+		return freshStyle.Render("●")
+	case d < 7*24*time.Hour:
+		return recentStyle.Render("●")
+	case d < 30*24*time.Hour:
+		return agingStyle.Render("●")
+	default:
+		return staleStyle.Render("●")
+	}
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alcxyz/canopy/internal/model"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -12,6 +13,14 @@ var (
 	activeTabStyle = lipgloss.NewStyle().Padding(0, 2).Bold(true).Foreground(lipgloss.Color("#cba6f7"))
 	titleStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#cba6f7"))
 	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086"))
+	stateColors    = map[model.TaskState]lipgloss.Style{
+		model.StateTodo:       lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")),
+		model.StateInProgress: lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")),
+		model.StateInReview:   lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")),
+		model.StateDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")),
+		model.StateClosed:     lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")),
+	}
+	typeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
 )
 
 func (m Model) View() string {
@@ -33,48 +42,88 @@ func (m Model) View() string {
 	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, tabs...))
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", m.width))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
+
+	// Loading indicator
+	if m.loading {
+		b.WriteString(dimStyle.Render("  loading..."))
+		b.WriteString("\n")
+	}
+
+	// Status / error
+	if m.statusMsg != "" && !m.loading {
+		b.WriteString(dimStyle.Render("  "+m.statusMsg))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
 
 	// Content
 	switch m.activeTab {
 	case tabMyTasks:
-		b.WriteString(m.renderTasks("my"))
+		b.WriteString(m.renderTaskList(m.myTasks))
 	case tabTeam:
-		b.WriteString(m.renderTasks("team"))
+		b.WriteString(m.renderTaskList(m.teamTasks))
 	case tabViews:
 		b.WriteString(m.renderViews())
 	}
 
 	// Footer
+	footer := "q quit • h/l tabs • j/k navigate • r refresh"
+	if m.activeTab == tabMyTasks || m.activeTab == tabTeam {
+		footer += " • o open"
+	}
+	if m.activeTab == tabViews {
+		footer += " • enter select view"
+	}
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("q quit • h/l tabs • j/k navigate"))
+	b.WriteString(dimStyle.Render(footer))
 
 	return b.String()
 }
 
-func (m Model) renderTasks(scope string) string {
-	if len(m.tasks) == 0 {
+func (m Model) renderTaskList(tasks []model.Task) string {
+	if len(tasks) == 0 {
 		if len(m.backends) == 0 {
-			return dimStyle.Render("No backends configured. Edit ~/.config/canopy/config.yaml")
+			return dimStyle.Render("  No backends configured. Edit ~/.config/canopy/config.yaml")
 		}
-		return dimStyle.Render("No tasks loaded. Backends are stubbed — implementation coming soon.")
+		if m.err != nil {
+			return dimStyle.Render(fmt.Sprintf("  Error: %v", m.err))
+		}
+		return dimStyle.Render("  No tasks found.")
 	}
 
 	var b strings.Builder
-	for i, t := range m.tasks {
+
+	// Header
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-14s %-14s %-20s %s", "STATE", "TYPE", "ASSIGNEE", "TITLE")))
+	b.WriteString("\n")
+
+	for i, t := range tasks {
 		prefix := "  "
 		if i == m.cursor {
 			prefix = "> "
 		}
-		b.WriteString(fmt.Sprintf("%s%-12s %-14s %-20s %s\n",
-			prefix, t.State, t.Type, t.Assignee, t.Title))
+
+		ss := stateColors[t.State]
+		state := ss.Render(cell(string(t.State), 14))
+		typ := typeStyle.Render(cell(string(t.Type), 14))
+		assignee := cell(truncate(t.Assignee, 20), 20)
+		title := truncate(t.Title, m.width-55)
+
+		line := fmt.Sprintf("%s%s%s%s %s", prefix, state, typ, assignee, title)
+		if i == m.cursor {
+			line = selRow(line)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
 	}
 	return b.String()
 }
 
 func (m Model) renderViews() string {
 	if len(m.cfg.Views) == 0 {
-		return dimStyle.Render("No views configured. Add views to your config.yaml")
+		return dimStyle.Render("  No views configured. Add views to your config.yaml")
 	}
 
 	var b strings.Builder
@@ -87,7 +136,39 @@ func (m Model) renderViews() string {
 		if v.Description != "" {
 			desc = dimStyle.Render(" — " + v.Description)
 		}
-		b.WriteString(fmt.Sprintf("%s%s%s\n", prefix, titleStyle.Render(v.Name), desc))
+
+		line := fmt.Sprintf("%s%s%s", prefix, titleStyle.Render(v.Name), desc)
+		if i == m.cursor {
+			line = selRow(line)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// ── helpers (mirrored from grove) ───────────────────────────────────────
+
+func selRow(s string) string {
+	const bg = "\033[48;2;69;71;90m"
+	return bg + strings.ReplaceAll(s, "\033[0m", "\033[0m"+bg) + "\033[0m"
+}
+
+func cell(s string, w int) string {
+	pad := w - lipgloss.Width(s)
+	if pad <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", pad)
+}
+
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
 }

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/alcxyz/canopy/internal/model"
 	"github.com/charmbracelet/lipgloss"
@@ -13,6 +14,9 @@ var (
 	activeTabStyle = lipgloss.NewStyle().Padding(0, 2).Bold(true).Foreground(lipgloss.Color("#cba6f7"))
 	titleStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#cba6f7"))
 	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086"))
+	filterStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af"))
+	statusStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#9399b2"))
+	countStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa"))
 	stateColors    = map[model.TaskState]lipgloss.Style{
 		model.StateTodo:       lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")),
 		model.StateInProgress: lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")),
@@ -20,12 +24,24 @@ var (
 		model.StateDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")),
 		model.StateClosed:     lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")),
 	}
-	typeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
+	typeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
+	borderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("#585b70")).
+			Padding(1, 2)
 )
 
 func (m Model) View() string {
 	if !m.ready {
 		return "loading..."
+	}
+
+	// Overlays take over the full screen.
+	if m.showHelp {
+		return m.renderHelp()
+	}
+	if m.showSplash {
+		return m.renderSplash()
 	}
 
 	var b strings.Builder
@@ -40,47 +56,187 @@ func (m Model) View() string {
 		}
 	}
 	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, tabs...))
+
+	// Active filter indicator next to tabs
+	if indicator := m.filterIndicator(); indicator != "" {
+		b.WriteString("  ")
+		b.WriteString(filterStyle.Render(indicator))
+	}
+
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", m.width))
 	b.WriteString("\n")
 
-	// Loading indicator
-	if m.loading {
-		b.WriteString(dimStyle.Render("  loading..."))
+	// Text filter input
+	if m.filtering {
+		b.WriteString(filterStyle.Render("  / " + m.filterQuery + "█"))
 		b.WriteString("\n")
 	}
-
-	// Status / error
-	if m.statusMsg != "" && !m.loading {
-		b.WriteString(dimStyle.Render("  "+m.statusMsg))
-		b.WriteString("\n")
-	}
-
-	b.WriteString("\n")
 
 	// Content
 	switch m.activeTab {
 	case tabMyTasks:
-		b.WriteString(m.renderTaskList(m.myTasks))
+		b.WriteString(m.renderTaskList(m.filteredTasks(m.myTasks)))
 	case tabTeam:
-		b.WriteString(m.renderTaskList(m.teamTasks))
+		b.WriteString(m.renderTaskList(m.filteredTasks(m.teamTasks)))
+	case tabDone:
+		b.WriteString(m.renderTaskList(m.filteredTasks(m.doneTasks)))
 	case tabViews:
 		b.WriteString(m.renderViews())
 	}
 
-	// Footer
-	footer := "q quit • h/l tabs • j/k navigate • r refresh"
-	if m.activeTab == tabMyTasks || m.activeTab == tabTeam {
-		footer += " • o open"
-	}
-	if m.activeTab == tabViews {
-		footer += " • enter select view"
-	}
+	// Status bar + info bar (bottom 2 lines)
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render(footer))
+	b.WriteString(m.renderStatusBar())
+	b.WriteString("\n")
+	b.WriteString(m.renderInfoBar())
 
 	return b.String()
 }
+
+// ── Status bar ──────────────────────────────────────────────────────────
+
+func (m Model) renderStatusBar() string {
+	msg := m.statusMsg
+	if m.loading {
+		msg = "⏳ " + msg
+	}
+	if msg == "" {
+		msg = m.defaultStatusMsg()
+	}
+	return statusStyle.Render(msg)
+}
+
+func (m Model) defaultStatusMsg() string {
+	var parts []string
+	if n := len(m.myTasks); n > 0 {
+		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" my")
+	}
+	if n := len(m.teamTasks); n > 0 {
+		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" team")
+	}
+	if n := len(m.doneTasks); n > 0 {
+		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" done")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " · ")
+}
+
+// ── Info bar ────────────────────────────────────────────────────────────
+
+func (m Model) renderInfoBar() string {
+	return dimStyle.Render(m.infoBarText())
+}
+
+func (m Model) infoBarText() string {
+	if m.filtering {
+		return "type to filter · enter confirm · esc clear"
+	}
+
+	var parts []string
+
+	// Tab-specific counts
+	switch m.activeTab {
+	case tabMyTasks:
+		n := len(m.filteredTasks(m.myTasks))
+		parts = append(parts, fmt.Sprintf("%d tasks", n))
+	case tabTeam:
+		n := len(m.filteredTasks(m.teamTasks))
+		parts = append(parts, fmt.Sprintf("%d tasks", n))
+	case tabDone:
+		n := len(m.filteredTasks(m.doneTasks))
+		parts = append(parts, fmt.Sprintf("%d tasks", n))
+	case tabViews:
+		parts = append(parts, fmt.Sprintf("%d views", len(m.cfg.Views)))
+	}
+
+	// Date scope
+	parts = append(parts, m.dateScope)
+
+	// Hints
+	parts = append(parts, "? help")
+	parts = append(parts, "v"+m.version)
+
+	return strings.Join(parts, " · ")
+}
+
+// ── Filter indicator ────────────────────────────────────────────────────
+
+func (m Model) filterIndicator() string {
+	var parts []string
+	if m.filterQuery != "" {
+		parts = append(parts, fmt.Sprintf("/%s", m.filterQuery))
+	}
+	if m.cycleField != "" && m.cycleIdx >= 0 && m.cycleIdx < len(m.cycleValues) {
+		parts = append(parts, fmt.Sprintf("%s:%s", m.cycleField, m.cycleValues[m.cycleIdx]))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// ── Help overlay ────────────────────────────────────────────────────────
+
+func (m Model) renderHelp() string {
+	help := `Navigation:
+  j / k                    move down / up
+  gg / G                   first / last item
+  h / l                    previous / next tab
+  1–4                      switch to tab directly
+
+Filters:
+  /                        text search · esc clear
+  f                        cycle date (this week → last week → month → quarter)
+  d                        cycle by assignee
+  s                        cycle by type (feature, bug, user-story…)
+  esc                      clear all filters
+
+Actions:
+  o                        open task in browser
+  r                        refresh data
+  enter                    select view (Views tab)
+  !                        about / paths
+  ?                        this help
+  q / ctrl+c               quit`
+
+	box := borderStyle.Width(min(72, m.width-4)).Render(
+		titleStyle.Render("canopy — help") + "\n\n" + help + "\n\n" +
+			dimStyle.Render("press ? or esc to close"),
+	)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// ── Splash overlay ──────────────────────────────────────────────────────
+
+func (m Model) renderSplash() string {
+	art := `
+     ╱╲
+    ╱  ╲
+   ╱ ╱╲ ╲
+  ╱ ╱  ╲ ╲
+ ╱ ╱    ╲ ╲
+╱ ╱______╲ ╲
+╲__________╱
+  canopy`
+
+	var info strings.Builder
+	info.WriteString(titleStyle.Render(art))
+	info.WriteString("\n\n")
+	info.WriteString(fmt.Sprintf("  %-14s %s\n", "version", m.version))
+	info.WriteString(fmt.Sprintf("  %-14s %s\n", "config", m.cfgPath))
+	info.WriteString(fmt.Sprintf("  %-14s %s\n", "cache", m.cacheDir))
+	info.WriteString(fmt.Sprintf("  %-14s %s\n", "log", m.logPath))
+	info.WriteString("\n")
+	info.WriteString(dimStyle.Render("  press ! or esc to close"))
+
+	box := borderStyle.Width(min(64, m.width-4)).Render(info.String())
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// ── Task list rendering ─────────────────────────────────────────────────
 
 func (m Model) renderTaskList(tasks []model.Task) string {
 	if len(tasks) == 0 {
@@ -95,8 +251,16 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 
 	var b strings.Builder
 
-	// Header
-	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-14s %-14s %-20s %s", "STATE", "TYPE", "ASSIGNEE", "TITLE")))
+	// Header — grove pattern: primary content first, metadata last (dimmed)
+	// TITLE(flex) PARENT(20) STATE(12) TYPE(12) ASSIGNEE(16) UPDATED(7) CREATED(7)
+	metaWidth := 20 + 12 + 12 + 16 + 7 + 7 // 74
+	titleWidth := m.width - metaWidth - 3   // 2 prefix + 1 space
+	if titleWidth < 16 {
+		titleWidth = 16
+	}
+
+	b.WriteString(dimStyle.Render(fmt.Sprintf("  %-*s %-20s %-12s %-12s %-16s %-7s %-7s",
+		titleWidth, "TITLE", "PARENT", "STATE", "TYPE", "ASSIGNEE", "UPDATED", "CREATED")))
 	b.WriteString("\n")
 
 	for i, t := range tasks {
@@ -105,13 +269,16 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 			prefix = "> "
 		}
 
+		title := cell(truncate(t.Title, titleWidth), titleWidth)
+		parent := dimStyle.Render(cell(truncate(t.ParentTitle, 20), 20))
 		ss := stateColors[t.State]
-		state := ss.Render(cell(string(t.State), 14))
-		typ := typeStyle.Render(cell(string(t.Type), 14))
-		assignee := cell(truncate(t.Assignee, 20), 20)
-		title := truncate(t.Title, m.width-55)
+		state := ss.Render(cell(string(t.State), 12))
+		typ := typeStyle.Render(cell(string(t.Type), 12))
+		assignee := dimStyle.Render(cell(truncate(t.Assignee, 16), 16))
+		updated := dimStyle.Render(cell(timeAgo(t.UpdatedAt), 7))
+		created := dimStyle.Render(cell(timeAgo(t.CreatedAt), 7))
 
-		line := fmt.Sprintf("%s%s%s%s %s", prefix, state, typ, assignee, title)
+		line := fmt.Sprintf("%s%s %s%s%s%s%s%s", prefix, title, parent, state, typ, assignee, updated, created)
 		if i == m.cursor {
 			line = selRow(line)
 		}
@@ -147,7 +314,28 @@ func (m Model) renderViews() string {
 	return b.String()
 }
 
-// ── helpers (mirrored from grove) ───────────────────────────────────────
+// ── helpers ─────────────────────────────────────────────────────────────
+
+func timeAgo(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dw", int(d.Hours()/(24*7)))
+	default:
+		return fmt.Sprintf("%dmo", int(d.Hours()/(24*30)))
+	}
+}
 
 func selRow(s string) string {
 	const bg = "\033[48;2;69;71;90m"

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -2,7 +2,15 @@ package backend
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/alcxyz/canopy/internal/config"
 	"github.com/alcxyz/canopy/internal/model"
@@ -10,26 +18,307 @@ import (
 
 type azureBoards struct {
 	profile config.Profile
+	client  *http.Client
+	token   string
+	baseURL string // https://dev.azure.com/{org}/{project}
 }
 
 func newAzureBoards(p config.Profile) (Backend, error) {
 	if p.Org == "" || p.Project == "" {
 		return nil, fmt.Errorf("azure-boards: org and project are required")
 	}
-	return &azureBoards{profile: p}, nil
+	token, err := resolveToken(p)
+	if err != nil {
+		return nil, fmt.Errorf("azure-boards: %w", err)
+	}
+	return &azureBoards{
+		profile: p,
+		client:  &http.Client{Timeout: 30 * time.Second},
+		token:   token,
+		baseURL: fmt.Sprintf("https://dev.azure.com/%s/%s", p.Org, p.Project),
+	}, nil
+}
+
+func resolveToken(p config.Profile) (string, error) {
+	if v := os.Getenv("AZURE_DEVOPS_PAT"); v != "" {
+		return v, nil
+	}
+	if p.TokenFile != "" {
+		data, err := os.ReadFile(p.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("reading token_file %q: %w", p.TokenFile, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	return "", fmt.Errorf("set AZURE_DEVOPS_PAT env var or token_file in config")
 }
 
 func (a *azureBoards) Name() string { return a.profile.Name }
 
-func (a *azureBoards) ListTasks(ctx context.Context, filter config.Filter) ([]model.Task, error) {
-	// TODO: implement Azure DevOps REST API calls
-	return nil, fmt.Errorf("azure-boards: not yet implemented")
+func (a *azureBoards) authHeader() string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+a.token))
 }
+
+func (a *azureBoards) doRequest(ctx context.Context, method, url string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", a.authHeader())
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(data))
+	}
+	return data, nil
+}
+
+// ── ListTasks ───────────────────────────────────────────────────────────
+
+func (a *azureBoards) ListTasks(ctx context.Context, filter config.Filter) ([]model.Task, error) {
+	// If filter needs current sprint, resolve the iteration path first.
+	iterPath := ""
+	if filter.Sprint == "current" {
+		path, err := a.currentIterationPath(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolving current sprint: %w", err)
+		}
+		iterPath = path
+	}
+
+	query := buildWIQL(filter, a.profile.Team, iterPath)
+	ids, err := a.queryWIQL(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	return a.fetchWorkItems(ctx, ids)
+}
+
+func (a *azureBoards) queryWIQL(ctx context.Context, query string) ([]int, error) {
+	payload := fmt.Sprintf(`{"query": %s}`, strconv.Quote(query))
+	url := a.baseURL + "/_apis/wit/wiql?api-version=7.0&$top=200"
+	data, err := a.doRequest(ctx, "POST", url, strings.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("WIQL query: %w", err)
+	}
+
+	var resp wiqlResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parsing WIQL response: %w", err)
+	}
+
+	ids := make([]int, len(resp.WorkItems))
+	for i, wi := range resp.WorkItems {
+		ids[i] = wi.ID
+	}
+	return ids, nil
+}
+
+func (a *azureBoards) fetchWorkItems(ctx context.Context, ids []int) ([]model.Task, error) {
+	var tasks []model.Task
+
+	// Azure limits batch to 200 IDs per request.
+	for i := 0; i < len(ids); i += 200 {
+		end := i + 200
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[i:end]
+
+		idStrs := make([]string, len(chunk))
+		for j, id := range chunk {
+			idStrs[j] = strconv.Itoa(id)
+		}
+
+		url := fmt.Sprintf("%s/_apis/wit/workitems?ids=%s&$expand=links&api-version=7.0",
+			a.baseURL, strings.Join(idStrs, ","))
+		data, err := a.doRequest(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("fetching work items: %w", err)
+		}
+
+		var resp workItemsResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, fmt.Errorf("parsing work items: %w", err)
+		}
+
+		for _, wi := range resp.Value {
+			tasks = append(tasks, a.mapWorkItem(wi))
+		}
+	}
+
+	return tasks, nil
+}
+
+func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
+	assignee := ""
+	if wi.Fields.AssignedTo.DisplayName != "" {
+		assignee = wi.Fields.AssignedTo.DisplayName
+	}
+
+	webURL := ""
+	if wi.Links.HTML.Href != "" {
+		webURL = wi.Links.HTML.Href
+	}
+
+	var labels []string
+	if wi.Fields.Tags != "" {
+		for _, t := range strings.Split(wi.Fields.Tags, ";") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				labels = append(labels, t)
+			}
+		}
+	}
+
+	return model.Task{
+		ID:        strconv.Itoa(wi.ID),
+		Title:     wi.Fields.Title,
+		State:     mapAzureState(wi.Fields.State),
+		Type:      mapAzureType(wi.Fields.WorkItemType),
+		Assignee:  assignee,
+		Labels:    labels,
+		Sprint:    wi.Fields.IterationPath,
+		URL:       webURL,
+		Profile:   a.profile.Name,
+		Backend:   string(config.BackendAzureBoards),
+		CreatedAt: wi.Fields.CreatedDate,
+		UpdatedAt: wi.Fields.ChangedDate,
+	}
+}
+
+// ── ListSprints ─────────────────────────────────────────────────────────
 
 func (a *azureBoards) ListSprints(ctx context.Context) ([]model.Sprint, error) {
-	return nil, fmt.Errorf("azure-boards: not yet implemented")
+	team := a.teamName()
+	url := fmt.Sprintf("%s/%s/_apis/work/teamsettings/iterations?api-version=7.0",
+		a.baseURL, team)
+	data, err := a.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing iterations: %w", err)
+	}
+
+	var resp iterationsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("parsing iterations: %w", err)
+	}
+
+	sprints := make([]model.Sprint, len(resp.Value))
+	for i, it := range resp.Value {
+		sprints[i] = model.Sprint{
+			ID:        it.ID,
+			Name:      it.Name,
+			StartDate: it.Attributes.StartDate,
+			EndDate:   it.Attributes.FinishDate,
+			Profile:   a.profile.Name,
+		}
+	}
+	return sprints, nil
 }
 
-func (a *azureBoards) ListTeam(ctx context.Context) ([]model.TeamMember, error) {
-	return nil, fmt.Errorf("azure-boards: not yet implemented")
+func (a *azureBoards) currentIterationPath(ctx context.Context) (string, error) {
+	team := a.teamName()
+	url := fmt.Sprintf("%s/%s/_apis/work/teamsettings/iterations?$timeframe=current&api-version=7.0",
+		a.baseURL, team)
+	data, err := a.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var resp iterationsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", err
+	}
+	if len(resp.Value) == 0 {
+		return "", fmt.Errorf("no current iteration found")
+	}
+	return resp.Value[0].Path, nil
+}
+
+func (a *azureBoards) teamName() string {
+	if a.profile.AzureTeam != "" {
+		return a.profile.AzureTeam
+	}
+	return a.profile.Project + " Team"
+}
+
+// ── ListTeam ────────────────────────────────────────────────────────────
+
+func (a *azureBoards) ListTeam(_ context.Context) ([]model.TeamMember, error) {
+	members := make([]model.TeamMember, len(a.profile.Team))
+	for i, t := range a.profile.Team {
+		members[i] = model.TeamMember{
+			ID:      t,
+			Name:    t,
+			Email:   t,
+			Profile: a.profile.Name,
+		}
+	}
+	return members, nil
+}
+
+// ── Azure DevOps response types ─────────────────────────────────────────
+
+type wiqlResponse struct {
+	WorkItems []struct {
+		ID int `json:"id"`
+	} `json:"workItems"`
+}
+
+type workItemsResponse struct {
+	Value []workItem `json:"value"`
+}
+
+type workItem struct {
+	ID     int           `json:"id"`
+	Fields workItemFields `json:"fields"`
+	Links  struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"_links"`
+}
+
+type workItemFields struct {
+	Title         string        `json:"System.Title"`
+	State         string        `json:"System.State"`
+	WorkItemType  string        `json:"System.WorkItemType"`
+	AssignedTo    assignedTo    `json:"System.AssignedTo"`
+	Tags          string        `json:"System.Tags"`
+	IterationPath string        `json:"System.IterationPath"`
+	CreatedDate   time.Time     `json:"System.CreatedDate"`
+	ChangedDate   time.Time     `json:"System.ChangedDate"`
+}
+
+type assignedTo struct {
+	DisplayName string `json:"displayName"`
+	UniqueName  string `json:"uniqueName"`
+}
+
+type iterationsResponse struct {
+	Value []iteration `json:"value"`
+}
+
+type iteration struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	Attributes struct {
+		StartDate  time.Time `json:"startDate"`
+		FinishDate time.Time `json:"finishDate"`
+	} `json:"attributes"`
 }

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -2,12 +2,11 @@ package backend
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +18,6 @@ import (
 type azureBoards struct {
 	profile config.Profile
 	client  *http.Client
-	token   string
 	baseURL string // https://dev.azure.com/{org}/{project}
 }
 
@@ -27,44 +25,47 @@ func newAzureBoards(p config.Profile) (Backend, error) {
 	if p.Org == "" || p.Project == "" {
 		return nil, fmt.Errorf("azure-boards: org and project are required")
 	}
-	token, err := resolveToken(p)
-	if err != nil {
-		return nil, fmt.Errorf("azure-boards: %w", err)
-	}
 	return &azureBoards{
 		profile: p,
 		client:  &http.Client{Timeout: 30 * time.Second},
-		token:   token,
 		baseURL: fmt.Sprintf("https://dev.azure.com/%s/%s", p.Org, p.Project),
 	}, nil
 }
 
-func resolveToken(p config.Profile) (string, error) {
-	if v := os.Getenv("AZURE_DEVOPS_PAT"); v != "" {
-		return v, nil
-	}
-	if p.TokenFile != "" {
-		data, err := os.ReadFile(p.TokenFile)
-		if err != nil {
-			return "", fmt.Errorf("reading token_file %q: %w", p.TokenFile, err)
-		}
-		return strings.TrimSpace(string(data)), nil
-	}
-	return "", fmt.Errorf("set AZURE_DEVOPS_PAT env var or token_file in config")
-}
-
 func (a *azureBoards) Name() string { return a.profile.Name }
 
-func (a *azureBoards) authHeader() string {
-	return "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+a.token))
+// getAzToken acquires a short-lived Bearer token for Azure DevOps via the az CLI.
+// The az CLI caches and refreshes tokens internally; no caching is needed here.
+func getAzToken(ctx context.Context) (string, error) {
+	const azureDevOpsResource = "499b84ac-1321-427f-aa17-267ca6975798"
+	out, err := exec.CommandContext(ctx, "az", "account", "get-access-token",
+		"--resource", azureDevOpsResource).Output()
+	if err != nil {
+		return "", fmt.Errorf("azure-boards: az CLI not found or not logged in — run 'az login' first")
+	}
+	var result struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("azure-boards: failed to parse az token response: %w", err)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("azure-boards: az returned empty access token — run 'az login' first")
+	}
+	return result.AccessToken, nil
 }
 
 func (a *azureBoards) doRequest(ctx context.Context, method, url string, body io.Reader) ([]byte, error) {
+	token, err := getAzToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", a.authHeader())
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := a.client.Do(req)
@@ -96,7 +97,7 @@ func (a *azureBoards) ListTasks(ctx context.Context, filter config.Filter) ([]mo
 		iterPath = path
 	}
 
-	query := buildWIQL(filter, a.profile.Team, iterPath)
+	query := buildWIQL(filter, a.profile.Project, a.profile.Team, iterPath)
 	ids, err := a.queryWIQL(ctx, query)
 	if err != nil {
 		return nil, err
@@ -105,7 +106,15 @@ func (a *azureBoards) ListTasks(ctx context.Context, filter config.Filter) ([]mo
 		return nil, nil
 	}
 
-	return a.fetchWorkItems(ctx, ids)
+	tasks, err := a.fetchWorkItems(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve parent titles in a single batch.
+	a.resolveParentTitles(ctx, tasks)
+
+	return tasks, nil
 }
 
 func (a *azureBoards) queryWIQL(ctx context.Context, query string) ([]int, error) {
@@ -144,7 +153,7 @@ func (a *azureBoards) fetchWorkItems(ctx context.Context, ids []int) ([]model.Ta
 			idStrs[j] = strconv.Itoa(id)
 		}
 
-		url := fmt.Sprintf("%s/_apis/wit/workitems?ids=%s&$expand=links&api-version=7.0",
+		url := fmt.Sprintf("%s/_apis/wit/workitems?ids=%s&$expand=all&api-version=7.0",
 			a.baseURL, strings.Join(idStrs, ","))
 		data, err := a.doRequest(ctx, "GET", url, nil)
 		if err != nil {
@@ -162,6 +171,80 @@ func (a *azureBoards) fetchWorkItems(ctx context.Context, ids []int) ([]model.Ta
 	}
 
 	return tasks, nil
+}
+
+// resolveParentTitles batch-fetches parent work item titles and fills
+// them into the tasks. Best-effort: errors are silently ignored.
+func (a *azureBoards) resolveParentTitles(ctx context.Context, tasks []model.Task) {
+	// Collect unique parent IDs that aren't already in the task set.
+	taskIDs := map[string]bool{}
+	for _, t := range tasks {
+		taskIDs[t.ID] = true
+	}
+	parentIDs := map[string]bool{}
+	for _, t := range tasks {
+		if t.ParentID != "" && !taskIDs[t.ParentID] {
+			parentIDs[t.ParentID] = true
+		}
+	}
+	if len(parentIDs) == 0 {
+		// All parents are in the task set already — resolve from there.
+		titleMap := map[string]string{}
+		for _, t := range tasks {
+			titleMap[t.ID] = t.Title
+		}
+		for i := range tasks {
+			if tasks[i].ParentID != "" {
+				tasks[i].ParentTitle = titleMap[tasks[i].ParentID]
+			}
+		}
+		return
+	}
+
+	// Fetch parent work items (just need titles).
+	var ids []int
+	for id := range parentIDs {
+		if n, err := strconv.Atoi(id); err == nil {
+			ids = append(ids, n)
+		}
+	}
+	idStrs := make([]string, len(ids))
+	for i, id := range ids {
+		idStrs[i] = strconv.Itoa(id)
+	}
+
+	titleMap := map[string]string{}
+	// Also include titles from tasks we already have.
+	for _, t := range tasks {
+		titleMap[t.ID] = t.Title
+	}
+
+	// Batch fetch in chunks of 200.
+	for i := 0; i < len(idStrs); i += 200 {
+		end := i + 200
+		if end > len(idStrs) {
+			end = len(idStrs)
+		}
+		url := fmt.Sprintf("%s/_apis/wit/workitems?ids=%s&fields=System.Title&api-version=7.0",
+			a.baseURL, strings.Join(idStrs[i:end], ","))
+		data, err := a.doRequest(ctx, "GET", url, nil)
+		if err != nil {
+			continue // best-effort
+		}
+		var resp workItemsResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			continue
+		}
+		for _, wi := range resp.Value {
+			titleMap[strconv.Itoa(wi.ID)] = wi.Fields.Title
+		}
+	}
+
+	for i := range tasks {
+		if tasks[i].ParentID != "" {
+			tasks[i].ParentTitle = titleMap[tasks[i].ParentID]
+		}
+	}
 }
 
 func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
@@ -185,6 +268,11 @@ func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
 		}
 	}
 
+	parentID := ""
+	if wi.Fields.Parent > 0 {
+		parentID = strconv.Itoa(wi.Fields.Parent)
+	}
+
 	return model.Task{
 		ID:        strconv.Itoa(wi.ID),
 		Title:     wi.Fields.Title,
@@ -196,6 +284,7 @@ func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
 		URL:       webURL,
 		Profile:   a.profile.Name,
 		Backend:   string(config.BackendAzureBoards),
+		ParentID:  parentID,
 		CreatedAt: wi.Fields.CreatedDate,
 		UpdatedAt: wi.Fields.ChangedDate,
 	}
@@ -300,6 +389,7 @@ type workItemFields struct {
 	AssignedTo    assignedTo    `json:"System.AssignedTo"`
 	Tags          string        `json:"System.Tags"`
 	IterationPath string        `json:"System.IterationPath"`
+	Parent        int           `json:"System.Parent"`
 	CreatedDate   time.Time     `json:"System.CreatedDate"`
 	ChangedDate   time.Time     `json:"System.ChangedDate"`
 }

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -15,6 +15,14 @@ import (
 	"github.com/alcxyz/canopy/internal/model"
 )
 
+// sem is a counting semaphore that limits concurrent Azure DevOps API calls
+// to 5. Azure DevOps has a per-user rate limit; capping concurrency prevents
+// exhausting the budget when multiple profiles or refreshes overlap.
+var sem = make(chan struct{}, 5)
+
+func acquire() { sem <- struct{}{} }
+func release() { <-sem }
+
 type azureBoards struct {
 	profile config.Profile
 	client  *http.Client
@@ -56,6 +64,9 @@ func getAzToken(ctx context.Context) (string, error) {
 }
 
 func (a *azureBoards) doRequest(ctx context.Context, method, url string, body io.Reader) ([]byte, error) {
+	acquire()
+	defer release()
+
 	token, err := getAzToken(ctx)
 	if err != nil {
 		return nil, err
@@ -285,8 +296,12 @@ func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
 		Profile:   a.profile.Name,
 		Backend:   string(config.BackendAzureBoards),
 		ParentID:  parentID,
-		CreatedAt: wi.Fields.CreatedDate,
-		UpdatedAt: wi.Fields.ChangedDate,
+		CreatedAt:      wi.Fields.CreatedDate,
+		UpdatedAt:      wi.Fields.ChangedDate,
+		StartDate:      wi.Fields.StartDate,
+		TargetDate:     wi.Fields.TargetDate,
+		ClosedAt:       wi.Fields.ClosedDate,
+		StateChangedAt: wi.Fields.StateChangeDate,
 	}
 }
 
@@ -383,15 +398,19 @@ type workItem struct {
 }
 
 type workItemFields struct {
-	Title         string        `json:"System.Title"`
-	State         string        `json:"System.State"`
-	WorkItemType  string        `json:"System.WorkItemType"`
-	AssignedTo    assignedTo    `json:"System.AssignedTo"`
-	Tags          string        `json:"System.Tags"`
-	IterationPath string        `json:"System.IterationPath"`
-	Parent        int           `json:"System.Parent"`
-	CreatedDate   time.Time     `json:"System.CreatedDate"`
-	ChangedDate   time.Time     `json:"System.ChangedDate"`
+	Title            string     `json:"System.Title"`
+	State            string     `json:"System.State"`
+	WorkItemType     string     `json:"System.WorkItemType"`
+	AssignedTo       assignedTo `json:"System.AssignedTo"`
+	Tags             string     `json:"System.Tags"`
+	IterationPath    string     `json:"System.IterationPath"`
+	Parent           int        `json:"System.Parent"`
+	CreatedDate      time.Time  `json:"System.CreatedDate"`
+	ChangedDate      time.Time  `json:"System.ChangedDate"`
+	StartDate        time.Time  `json:"Microsoft.VSTS.Scheduling.StartDate"`
+	TargetDate       time.Time  `json:"Microsoft.VSTS.Scheduling.TargetDate"`
+	ClosedDate       time.Time  `json:"Microsoft.VSTS.Common.ClosedDate"`
+	StateChangeDate  time.Time  `json:"Microsoft.VSTS.Common.StateChangeDate"`
 }
 
 type assignedTo struct {

--- a/internal/backend/azure_wiql.go
+++ b/internal/backend/azure_wiql.go
@@ -1,0 +1,174 @@
+package backend
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alcxyz/canopy/internal/config"
+	"github.com/alcxyz/canopy/internal/model"
+)
+
+// ── State mapping ───────────────────────────────────────────────────────
+
+// canopy → Azure DevOps state names (covers Agile + CMMI process templates).
+var stateToAzure = map[model.TaskState][]string{
+	model.StateTodo:       {"New", "Proposed"},
+	model.StateInProgress: {"Active", "Committed"},
+	model.StateInReview:   {"Resolved"},
+	model.StateDone:       {"Closed", "Done"},
+	model.StateClosed:     {"Closed", "Done", "Removed"},
+}
+
+// Azure → canopy (reverse lookup).
+var azureToState = map[string]model.TaskState{
+	"New":       model.StateTodo,
+	"Proposed":  model.StateTodo,
+	"Active":    model.StateInProgress,
+	"Committed": model.StateInProgress,
+	"Resolved":  model.StateInReview,
+	"Closed":    model.StateDone,
+	"Done":      model.StateDone,
+	"Removed":   model.StateClosed,
+}
+
+func mapAzureState(s string) model.TaskState {
+	if st, ok := azureToState[s]; ok {
+		return st
+	}
+	return model.TaskState(strings.ToLower(s))
+}
+
+// ── Type mapping ────────────────────────────────────────────────────────
+
+var typeToAzure = map[model.TaskType]string{
+	model.TypeFeature:   "Feature",
+	model.TypeBug:       "Bug",
+	model.TypeUserStory: "User Story",
+	model.TypeTask:      "Task",
+	model.TypeEpic:      "Epic",
+	model.TypeSubtask:   "Task",
+}
+
+var azureToType = map[string]model.TaskType{
+	"Feature":    model.TypeFeature,
+	"Bug":        model.TypeBug,
+	"User Story": model.TypeUserStory,
+	"Task":       model.TypeTask,
+	"Epic":       model.TypeEpic,
+}
+
+func mapAzureType(s string) model.TaskType {
+	if t, ok := azureToType[s]; ok {
+		return t
+	}
+	return model.TaskType(strings.ToLower(s))
+}
+
+// ── WIQL query builder ──────────────────────────────────────────────────
+
+// buildWIQL constructs a WIQL query from a canopy filter.
+// iterPath is the resolved iteration path (only needed when filter.Sprint == "current").
+func buildWIQL(filter config.Filter, team []string, iterPath string) string {
+	var clauses []string
+
+	// Types
+	if len(filter.Types) > 0 {
+		var azTypes []string
+		for _, t := range filter.Types {
+			if az, ok := typeToAzure[model.TaskType(t)]; ok {
+				azTypes = append(azTypes, quote(az))
+			}
+		}
+		if len(azTypes) > 0 {
+			clauses = append(clauses,
+				fmt.Sprintf("[System.WorkItemType] IN (%s)", strings.Join(azTypes, ", ")))
+		}
+	}
+
+	// Status
+	if len(filter.Status) > 0 {
+		seen := map[string]bool{}
+		var azStates []string
+		for _, s := range filter.Status {
+			for _, az := range stateToAzure[model.TaskState(s)] {
+				if !seen[az] {
+					seen[az] = true
+					azStates = append(azStates, quote(az))
+				}
+			}
+		}
+		if len(azStates) > 0 {
+			clauses = append(clauses,
+				fmt.Sprintf("[System.State] IN (%s)", strings.Join(azStates, ", ")))
+		}
+	}
+
+	// Updated since
+	if filter.UpdatedSince != "" {
+		if days := updatedSinceDays(filter.UpdatedSince); days > 0 {
+			clauses = append(clauses,
+				fmt.Sprintf("[System.ChangedDate] >= @today - %d", days))
+		}
+	}
+
+	// Assignee
+	if filter.Assignee == "me" {
+		clauses = append(clauses, "[System.AssignedTo] = @me")
+	} else if filter.Assignee != "" {
+		clauses = append(clauses,
+			fmt.Sprintf("[System.AssignedTo] = %s", quote(filter.Assignee)))
+	} else if len(team) > 0 {
+		// No specific assignee but team is configured — filter to team members.
+		quoted := make([]string, len(team))
+		for i, m := range team {
+			quoted[i] = quote(m)
+		}
+		clauses = append(clauses,
+			fmt.Sprintf("[System.AssignedTo] IN (%s)", strings.Join(quoted, ", ")))
+	}
+
+	// Sprint / iteration
+	if iterPath != "" {
+		clauses = append(clauses,
+			fmt.Sprintf("[System.IterationPath] = %s", quote(iterPath)))
+	} else if filter.Sprint != "" && filter.Sprint != "current" {
+		clauses = append(clauses,
+			fmt.Sprintf("[System.IterationPath] = %s", quote(filter.Sprint)))
+	}
+
+	// Labels / tags
+	for _, label := range filter.Labels {
+		clauses = append(clauses,
+			fmt.Sprintf("[System.Tags] CONTAINS %s", quote(label)))
+	}
+
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+
+	return "SELECT [System.Id] FROM WorkItems" + where + " ORDER BY [System.ChangedDate] DESC"
+}
+
+func updatedSinceDays(s string) int {
+	switch s {
+	case "today":
+		return 0
+	case "yesterday":
+		return 1
+	case "last_week":
+		return 7
+	case "last_2_weeks":
+		return 14
+	case "last_month":
+		return 30
+	case "last_quarter":
+		return 90
+	default:
+		return 0
+	}
+}
+
+func quote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/internal/backend/azure_wiql.go
+++ b/internal/backend/azure_wiql.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/alcxyz/canopy/internal/config"
@@ -67,9 +68,15 @@ func mapAzureType(s string) model.TaskType {
 // ── WIQL query builder ──────────────────────────────────────────────────
 
 // buildWIQL constructs a WIQL query from a canopy filter.
+// project scopes results to a single Azure DevOps project.
 // iterPath is the resolved iteration path (only needed when filter.Sprint == "current").
-func buildWIQL(filter config.Filter, team []string, iterPath string) string {
+func buildWIQL(filter config.Filter, project string, team []string, iterPath string) string {
 	var clauses []string
+
+	// Always scope to the configured project.
+	if project != "" {
+		clauses = append(clauses, fmt.Sprintf("[System.TeamProject] = %s", quote(project)))
+	}
 
 	// Types
 	if len(filter.Types) > 0 {
@@ -165,6 +172,13 @@ func updatedSinceDays(s string) int {
 	case "last_quarter":
 		return 90
 	default:
+		// Support "last_N_days" dynamic format.
+		if strings.HasPrefix(s, "last_") && strings.HasSuffix(s, "_days") {
+			mid := s[len("last_") : len(s)-len("_days")]
+			if n, err := strconv.Atoi(mid); err == nil {
+				return n
+			}
+		}
 		return 0
 	}
 }

--- a/internal/backend/azure_wiql_test.go
+++ b/internal/backend/azure_wiql_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildWIQL_EmptyFilter(t *testing.T) {
-	q := buildWIQL(config.Filter{}, nil, "")
+	q := buildWIQL(config.Filter{}, "", nil, "")
 	want := "SELECT [System.Id] FROM WorkItems ORDER BY [System.ChangedDate] DESC"
 	if q != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", q, want)
@@ -16,14 +16,14 @@ func TestBuildWIQL_EmptyFilter(t *testing.T) {
 }
 
 func TestBuildWIQL_Types(t *testing.T) {
-	q := buildWIQL(config.Filter{Types: []string{"feature", "bug"}}, nil, "")
+	q := buildWIQL(config.Filter{Types: []string{"feature", "bug"}}, "", nil, "")
 	if !strings.Contains(q, "[System.WorkItemType] IN ('Feature', 'Bug')") {
 		t.Errorf("expected type clause, got: %s", q)
 	}
 }
 
 func TestBuildWIQL_Status(t *testing.T) {
-	q := buildWIQL(config.Filter{Status: []string{"in-progress", "done"}}, nil, "")
+	q := buildWIQL(config.Filter{Status: []string{"in-progress", "done"}}, "", nil, "")
 	if !strings.Contains(q, "[System.State] IN (") {
 		t.Errorf("expected state clause, got: %s", q)
 	}
@@ -37,14 +37,14 @@ func TestBuildWIQL_Status(t *testing.T) {
 }
 
 func TestBuildWIQL_AssigneeMe(t *testing.T) {
-	q := buildWIQL(config.Filter{Assignee: "me"}, nil, "")
+	q := buildWIQL(config.Filter{Assignee: "me"}, "", nil, "")
 	if !strings.Contains(q, "[System.AssignedTo] = @me") {
 		t.Errorf("expected @me clause, got: %s", q)
 	}
 }
 
 func TestBuildWIQL_AssigneeSpecific(t *testing.T) {
-	q := buildWIQL(config.Filter{Assignee: "alice@example.com"}, nil, "")
+	q := buildWIQL(config.Filter{Assignee: "alice@example.com"}, "", nil, "")
 	if !strings.Contains(q, "[System.AssignedTo] = 'alice@example.com'") {
 		t.Errorf("expected specific assignee, got: %s", q)
 	}
@@ -52,7 +52,7 @@ func TestBuildWIQL_AssigneeSpecific(t *testing.T) {
 
 func TestBuildWIQL_TeamFilter(t *testing.T) {
 	team := []string{"alice@example.com", "bob@example.com"}
-	q := buildWIQL(config.Filter{}, team, "")
+	q := buildWIQL(config.Filter{}, "", team, "")
 	if !strings.Contains(q, "[System.AssignedTo] IN ('alice@example.com', 'bob@example.com')") {
 		t.Errorf("expected team IN clause, got: %s", q)
 	}
@@ -60,7 +60,7 @@ func TestBuildWIQL_TeamFilter(t *testing.T) {
 
 func TestBuildWIQL_TeamIgnoredWhenAssigneeSet(t *testing.T) {
 	team := []string{"alice@example.com"}
-	q := buildWIQL(config.Filter{Assignee: "me"}, team, "")
+	q := buildWIQL(config.Filter{Assignee: "me"}, "", team, "")
 	// Should use @me, not the team IN clause
 	if strings.Contains(q, "IN (") {
 		t.Errorf("team filter should not be used when assignee is set, got: %s", q)
@@ -68,21 +68,21 @@ func TestBuildWIQL_TeamIgnoredWhenAssigneeSet(t *testing.T) {
 }
 
 func TestBuildWIQL_UpdatedSince(t *testing.T) {
-	q := buildWIQL(config.Filter{UpdatedSince: "last_week"}, nil, "")
+	q := buildWIQL(config.Filter{UpdatedSince: "last_week"}, "", nil, "")
 	if !strings.Contains(q, "[System.ChangedDate] >= @today - 7") {
 		t.Errorf("expected date clause, got: %s", q)
 	}
 }
 
 func TestBuildWIQL_Sprint(t *testing.T) {
-	q := buildWIQL(config.Filter{Sprint: "current"}, nil, "Project\\Sprint 5")
+	q := buildWIQL(config.Filter{Sprint: "current"}, "", nil, "Project\\Sprint 5")
 	if !strings.Contains(q, "[System.IterationPath] = 'Project\\Sprint 5'") {
 		t.Errorf("expected iteration clause, got: %s", q)
 	}
 }
 
 func TestBuildWIQL_Labels(t *testing.T) {
-	q := buildWIQL(config.Filter{Labels: []string{"frontend", "priority-high"}}, nil, "")
+	q := buildWIQL(config.Filter{Labels: []string{"frontend", "priority-high"}}, "", nil, "")
 	if !strings.Contains(q, "[System.Tags] CONTAINS 'frontend'") {
 		t.Errorf("expected first tag clause, got: %s", q)
 	}
@@ -97,11 +97,18 @@ func TestBuildWIQL_Combined(t *testing.T) {
 		Status:       []string{"in-progress"},
 		UpdatedSince: "last_week",
 		Assignee:     "me",
-	}, nil, "")
+	}, "", nil, "")
 
 	// All clauses joined with AND
 	if strings.Count(q, " AND ") != 3 {
 		t.Errorf("expected 3 AND clauses, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_ProjectFilter(t *testing.T) {
+	q := buildWIQL(config.Filter{}, "Bullet", nil, "")
+	if !strings.Contains(q, "[System.TeamProject] = 'Bullet'") {
+		t.Errorf("expected project clause, got: %s", q)
 	}
 }
 

--- a/internal/backend/azure_wiql_test.go
+++ b/internal/backend/azure_wiql_test.go
@@ -1,0 +1,152 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alcxyz/canopy/internal/config"
+)
+
+func TestBuildWIQL_EmptyFilter(t *testing.T) {
+	q := buildWIQL(config.Filter{}, nil, "")
+	want := "SELECT [System.Id] FROM WorkItems ORDER BY [System.ChangedDate] DESC"
+	if q != want {
+		t.Errorf("got:\n  %s\nwant:\n  %s", q, want)
+	}
+}
+
+func TestBuildWIQL_Types(t *testing.T) {
+	q := buildWIQL(config.Filter{Types: []string{"feature", "bug"}}, nil, "")
+	if !strings.Contains(q, "[System.WorkItemType] IN ('Feature', 'Bug')") {
+		t.Errorf("expected type clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_Status(t *testing.T) {
+	q := buildWIQL(config.Filter{Status: []string{"in-progress", "done"}}, nil, "")
+	if !strings.Contains(q, "[System.State] IN (") {
+		t.Errorf("expected state clause, got: %s", q)
+	}
+	// Should contain Azure state names
+	if !strings.Contains(q, "'Active'") {
+		t.Errorf("expected Active state, got: %s", q)
+	}
+	if !strings.Contains(q, "'Closed'") {
+		t.Errorf("expected Closed state, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_AssigneeMe(t *testing.T) {
+	q := buildWIQL(config.Filter{Assignee: "me"}, nil, "")
+	if !strings.Contains(q, "[System.AssignedTo] = @me") {
+		t.Errorf("expected @me clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_AssigneeSpecific(t *testing.T) {
+	q := buildWIQL(config.Filter{Assignee: "alice@example.com"}, nil, "")
+	if !strings.Contains(q, "[System.AssignedTo] = 'alice@example.com'") {
+		t.Errorf("expected specific assignee, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_TeamFilter(t *testing.T) {
+	team := []string{"alice@example.com", "bob@example.com"}
+	q := buildWIQL(config.Filter{}, team, "")
+	if !strings.Contains(q, "[System.AssignedTo] IN ('alice@example.com', 'bob@example.com')") {
+		t.Errorf("expected team IN clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_TeamIgnoredWhenAssigneeSet(t *testing.T) {
+	team := []string{"alice@example.com"}
+	q := buildWIQL(config.Filter{Assignee: "me"}, team, "")
+	// Should use @me, not the team IN clause
+	if strings.Contains(q, "IN (") {
+		t.Errorf("team filter should not be used when assignee is set, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_UpdatedSince(t *testing.T) {
+	q := buildWIQL(config.Filter{UpdatedSince: "last_week"}, nil, "")
+	if !strings.Contains(q, "[System.ChangedDate] >= @today - 7") {
+		t.Errorf("expected date clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_Sprint(t *testing.T) {
+	q := buildWIQL(config.Filter{Sprint: "current"}, nil, "Project\\Sprint 5")
+	if !strings.Contains(q, "[System.IterationPath] = 'Project\\Sprint 5'") {
+		t.Errorf("expected iteration clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_Labels(t *testing.T) {
+	q := buildWIQL(config.Filter{Labels: []string{"frontend", "priority-high"}}, nil, "")
+	if !strings.Contains(q, "[System.Tags] CONTAINS 'frontend'") {
+		t.Errorf("expected first tag clause, got: %s", q)
+	}
+	if !strings.Contains(q, "[System.Tags] CONTAINS 'priority-high'") {
+		t.Errorf("expected second tag clause, got: %s", q)
+	}
+}
+
+func TestBuildWIQL_Combined(t *testing.T) {
+	q := buildWIQL(config.Filter{
+		Types:        []string{"bug"},
+		Status:       []string{"in-progress"},
+		UpdatedSince: "last_week",
+		Assignee:     "me",
+	}, nil, "")
+
+	// All clauses joined with AND
+	if strings.Count(q, " AND ") != 3 {
+		t.Errorf("expected 3 AND clauses, got: %s", q)
+	}
+}
+
+func TestMapAzureState(t *testing.T) {
+	cases := []struct {
+		azure string
+		want  string
+	}{
+		{"New", "todo"},
+		{"Active", "in-progress"},
+		{"Resolved", "in-review"},
+		{"Closed", "done"},
+		{"Done", "done"},
+		{"Removed", "closed"},
+		{"Custom", "custom"}, // unknown maps to lowercase
+	}
+	for _, c := range cases {
+		if got := string(mapAzureState(c.azure)); got != c.want {
+			t.Errorf("mapAzureState(%q) = %q, want %q", c.azure, got, c.want)
+		}
+	}
+}
+
+func TestMapAzureType(t *testing.T) {
+	cases := []struct {
+		azure string
+		want  string
+	}{
+		{"Feature", "feature"},
+		{"Bug", "bug"},
+		{"User Story", "user-story"},
+		{"Task", "task"},
+		{"Epic", "epic"},
+		{"Custom Type", "custom type"}, // unknown maps to lowercase
+	}
+	for _, c := range cases {
+		if got := string(mapAzureType(c.azure)); got != c.want {
+			t.Errorf("mapAzureType(%q) = %q, want %q", c.azure, got, c.want)
+		}
+	}
+}
+
+func TestQuote_EscapesSingleQuotes(t *testing.T) {
+	got := quote("O'Brien")
+	if got != "'O''Brien'" {
+		t.Errorf("quote(O'Brien) = %s, want 'O''Brien'", got)
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,26 +7,31 @@ import (
 	"time"
 )
 
-// Entry wraps cached data with a timestamp for TTL checks.
+// Entry wraps cached data with a timestamp and config key for staleness and
+// invalidation checks.
 type Entry struct {
-	CachedAt time.Time       `json:"cached_at"`
-	Data     json.RawMessage `json:"data"`
+	CachedAt  time.Time       `json:"cached_at"`
+	ConfigKey string          `json:"config_key"`
+	Data      json.RawMessage `json:"data"`
 }
 
 // Store provides file-based caching in the XDG cache directory.
 type Store struct {
-	dir string
+	dir       string
+	configKey string
 }
 
-// New creates a Store at the given directory, creating it if needed.
-func New(dir string) (*Store, error) {
+// New creates a Store at the given directory with a config key for
+// invalidation. The directory is created if it does not exist.
+func New(dir, configKey string) (*Store, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
-	return &Store{dir: dir}, nil
+	return &Store{dir: dir, configKey: configKey}, nil
 }
 
-// Get reads a cached entry. Returns nil if missing or expired.
+// Get reads a cached entry. Returns nil if missing, expired, or if the
+// config key has changed since the entry was written.
 func (s *Store) Get(key string, ttl time.Duration) (*Entry, error) {
 	data, err := os.ReadFile(filepath.Join(s.dir, key+".json"))
 	if err != nil {
@@ -36,21 +41,25 @@ func (s *Store) Get(key string, ttl time.Duration) (*Entry, error) {
 	if err := json.Unmarshal(data, &e); err != nil {
 		return nil, nil
 	}
-	if time.Since(e.CachedAt) > ttl {
+	if e.ConfigKey != s.configKey {
+		return nil, nil
+	}
+	if ttl > 0 && time.Since(e.CachedAt) > ttl {
 		return nil, nil
 	}
 	return &e, nil
 }
 
-// Set writes data to the cache.
+// Set writes data to the cache, stamped with the current time and config key.
 func (s *Store) Set(key string, data any) error {
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
 	e := Entry{
-		CachedAt: time.Now(),
-		Data:     raw,
+		CachedAt:  time.Now(),
+		ConfigKey: s.configKey,
+		Data:      raw,
 	}
 	b, err := json.Marshal(e)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -65,6 +66,7 @@ type Profile struct {
 type Config struct {
 	Profiles    []Profile `yaml:"profiles"`
 	Views       []View    `yaml:"views"`
+	Tags        []string  `yaml:"tags"`        // preset tags for the t cycle filter
 	RefreshSecs int       `yaml:"refresh_secs"`
 }
 
@@ -142,6 +144,16 @@ func Load() Config {
 	}
 
 	return cfg
+}
+
+// CacheKey returns a string derived from profile settings so the cache is
+// automatically invalidated when the user changes org/project/owner.
+func (c Config) CacheKey() string {
+	var parts []string
+	for _, p := range c.Profiles {
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s", p.Backend, p.Org, p.Project, p.Owner))
+	}
+	return strings.Join(parts, ";")
 }
 
 // ViewByName returns the view with the given name, or nil if not found.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,8 +58,7 @@ type Profile struct {
 	AzureTeam string `yaml:"azure_team"`
 
 	// Common
-	Team      []string `yaml:"team"`       // team member identifiers
-	TokenFile string   `yaml:"token_file"` // path to file containing auth token
+	Team []string `yaml:"team"` // team member identifiers
 }
 
 // Config is the top-level canopy configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,8 +54,12 @@ type Profile struct {
 	// Linear
 	TeamID string `yaml:"team_id"`
 
+	// Azure Boards team name (defaults to "{Project} Team")
+	AzureTeam string `yaml:"azure_team"`
+
 	// Common
-	Team []string `yaml:"team"` // team member identifiers
+	Team      []string `yaml:"team"`       // team member identifiers
+	TokenFile string   `yaml:"token_file"` // path to file containing auth token
 }
 
 // Config is the top-level canopy configuration.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -27,18 +27,20 @@ const (
 
 // Task is the unified work item across all backends.
 type Task struct {
-	ID        string
-	Title     string
-	State     TaskState
-	Type      TaskType
-	Assignee  string
-	Labels    []string
-	Sprint    string
-	URL       string // web URL to open in browser
-	Profile   string // which profile this came from
-	Backend   string // backend type for display
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID          string
+	Title       string
+	State       TaskState
+	Type        TaskType
+	Assignee    string
+	Labels      []string
+	Sprint      string
+	URL         string // web URL to open in browser
+	Profile     string // which profile this came from
+	Backend     string // backend type for display
+	ParentID    string // parent work item ID (if any)
+	ParentTitle string // resolved parent title
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // Sprint represents an iteration/sprint across backends.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -39,8 +39,12 @@ type Task struct {
 	Backend     string // backend type for display
 	ParentID    string // parent work item ID (if any)
 	ParentTitle string // resolved parent title
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	StartDate      time.Time
+	TargetDate     time.Time
+	ClosedAt       time.Time
+	StateChangedAt time.Time
 }
 
 // Sprint represents an iteration/sprint across backends.


### PR DESCRIPTION
## Summary

Initial feature-complete release of canopy — a multi-backend task dashboard TUI.

- **Azure Boards backend** with az CLI authentication, WIQL queries, parent task resolution, and API rate limiting
- **Grove-style TUI** with four tabs (My Tasks, Team, Done, Views), vim navigation (j/k/h/l/gg/G), and configurable views
- **Cycle filters**: date (`f`), date-field (`F`), assignee (`d`), type (`s`), tag (`t`), plus `/` text search across all fields
- **Task drill-down navigation**: Enter to navigate into subtasks, Esc/Backspace to go back, `[`/`]` sibling navigation, breadcrumb trail
- **Infrastructure**: on-disk cache with config-key invalidation, version update check, clipboard copy, auto-refresh

### ADRs
- ADR-001: Backend interface abstraction
- ADR-002: Azure authentication via az CLI
- ADR-003: TUI navigation and filtering model
- ADR-004: Task drill-down navigation

Closes #3, closes #4

## Test plan
- [ ] Verify Azure Boards connection with `az login` and valid config
- [ ] Test tab navigation (h/l/1-4) and cursor movement (j/k/gg/G)
- [ ] Test cycle filters (f/F/d/s/t) and text search (/)
- [ ] Test Enter to drill into a parent task, verify subtasks shown
- [ ] Test Esc/Backspace to navigate back, breadcrumb updates
- [ ] Test [/] sibling navigation in both list and detail views
- [ ] Test i for detail overlay, o for browser, space for clipboard
- [ ] Verify cache loads on startup and invalidates on config change