### PR TITLE
ci: add CI workflow with lint, fmt, and race-detected tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check go.mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum || (echo "FAIL: go.mod/go.sum not tidy" && exit 1)
+
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "FAIL: files not formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11
+
+      - name: Test
+        run: go test -race ./...

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Views support these filter fields:
 | `j` / `k` | Move down / up |
 | `g` / `G` | First / last item |
 | `1` `2` `3` | Switch to tab directly |
+| `c` | Create work item |
 | `r` | Refresh tasks |
 | `enter` | Select view (Views tab) |
 | `o` | Open task in browser |

--- a/cmd/canopy/main.go
+++ b/cmd/canopy/main.go
@@ -35,7 +35,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "cannot open log: %v\n", err)
 		os.Exit(1)
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 
 	p := tea.NewProgram(
 		app.New(app.Options{

--- a/docs/adr/ADR-005-optional-task-creator-interface.md
+++ b/docs/adr/ADR-005-optional-task-creator-interface.md
@@ -1,0 +1,39 @@
+# ADR-005: Optional TaskCreator interface for write operations
+
+**Status:** Accepted
+**Date:** 2026-04-23
+**Applies to:** `internal/backend/backend.go`, `internal/backend/azure.go`
+
+## Context
+
+Canopy has been read-only since inception (ADR-001). Users now want to create work items from the TUI — starting with Azure Boards, where the typical workflow is creating a Feature with User Stories underneath it. The existing `Backend` interface defines three read methods (`ListTasks`, `ListSprints`, `ListTeam`). Adding write operations raises the question of how to extend the interface without breaking backends that don't support creation (GitHub, Jira, and Linear are currently stubs).
+
+## Decision
+
+Define a separate `TaskCreator` interface rather than extending the existing `Backend` interface. The TUI checks at runtime with a type assertion (`creator, ok := b.(TaskCreator)`). Backends that support creation implement both `Backend` and `TaskCreator`; those that don't need no changes.
+
+```go
+type TaskCreator interface {
+    CreateTask(ctx context.Context, params CreateTaskParams) (CreateTaskResult, error)
+    CurrentIteration(ctx context.Context) (string, error)
+}
+```
+
+`CurrentIteration` is bundled here because iteration context is needed to pre-populate the creation form and is only relevant when write operations are supported.
+
+The TUI form accepts plain text for descriptions; the backend is responsible for converting to its native format (HTML for Azure DevOps).
+
+## Alternatives Considered
+
+**Extend the `Backend` interface directly.** Rejected because it forces all stub backends to implement `CreateTask` with a `not implemented` error. This is noisy and error-prone as more backends are added. The optional interface pattern is idiomatic Go (cf. `io.Reader` vs `io.ReadCloser`).
+
+**Separate CLI subcommand instead of TUI form.** Rejected because the value of canopy is the unified dashboard — switching to a CLI for creation breaks the flow. The form overlay follows the existing overlay pattern (`showHelp`, `showDetail`) and feels native.
+
+**Use `az boards` CLI under the hood.** Rejected because it adds an external dependency and doesn't generalise to other backends. Direct API calls using the existing `doRequest` infrastructure are more reliable and consistent.
+
+## Consequences
+
+- Adding write support to a new backend means implementing `TaskCreator` — no changes to the core `Backend` interface or existing backends.
+- The TUI must check for `TaskCreator` support at runtime and gracefully disable the `c` key when no backend supports it.
+- Future write operations (update, delete) can follow the same optional interface pattern.
+- Description formatting is a backend concern — the TUI always works with plain text.

--- a/docs/adr/ADR-006-extended-create-fields.md
+++ b/docs/adr/ADR-006-extended-create-fields.md
@@ -1,0 +1,48 @@
+# ADR-006: Extend CreateTaskParams with delivery plan fields
+
+**Status:** Accepted
+**Date:** 2026-04-28
+**Applies to:** `internal/backend/backend.go`, `internal/backend/azure.go`, `internal/app/form.go`
+
+## Context
+
+The `TaskCreator` interface (ADR-005) supports creating work items with type, title, description, parent, iteration, and assignee. During delivery plan creation for the Bullet team, we discovered this is insufficient for Azure Boards milestones which require tags (`Milestone`, `CapEx`, `OpEx`, `Goal`), start/end dates, and acceptance criteria. The iteration and assignee fields are also read-only in the form, preventing overrides.
+
+These gaps forced all delivery plan work to be done via the `az boards` CLI (see `bn-bootstrap/bin/bullet-boards`), bypassing Canopy entirely.
+
+## Decision
+
+Extend `CreateTaskParams` with new fields rather than creating a separate interface:
+
+```go
+type CreateTaskParams struct {
+    // ... existing fields ...
+    DescriptionHTML    string   // pre-formatted HTML; takes precedence when set
+    Tags               []string // backend-agnostic labels
+    StartDate          string   // YYYY-MM-DD
+    TargetDate         string   // YYYY-MM-DD
+    AcceptanceCriteria string   // plain text; backends convert to native format
+}
+```
+
+The TUI form gains new editable fields: Tags, Start Date, End Date, Acceptance Criteria. Sprint and Assignee become editable (they were read-only). The form uses section grouping to keep the layout scannable.
+
+The Azure backend maps these to:
+- `System.Tags` (semicolon-separated)
+- `Microsoft.VSTS.Scheduling.StartDate`
+- `Microsoft.VSTS.Scheduling.TargetDate`
+- `Microsoft.VSTS.Common.AcceptanceCriteria`
+
+## Alternatives Considered
+
+- **New `DeliveryPlanCreator` interface.** Rejected because these fields are broadly useful, not delivery-plan-specific. Tags, dates, and acceptance criteria are standard Azure Boards features.
+- **Backend-specific config for default tags.** Rejected because it would hide important classification choices from the user. Tags like CapEx/OpEx are decisions, not defaults.
+- **Keep creation in `bullet-boards` only.** Rejected because Canopy's value is the unified dashboard. If creation requires switching to CLI, the TUI loses its purpose for write operations.
+
+## Consequences
+
+- Creating delivery plan milestones can be done entirely within Canopy.
+- The form grows from 3 to 9 editable fields. Section grouping and sensible defaults keep it usable.
+- `DescriptionHTML` enables future template support without changing the default plain-text flow.
+- Other backends (GitHub, Jira, Linear) can ignore fields they don't support since `CreateTaskParams` is a struct, not an interface.
+- Existing create operations (just type + title) continue to work with all new fields empty.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,3 +4,4 @@
 | [ADR-002](ADR-002-azure-auth-via-az-cli.md) | Azure authentication via az CLI | auth |
 | [ADR-003](ADR-003-tui-navigation-and-filtering.md) | TUI navigation and filtering model | UX |
 | [ADR-004](ADR-004-task-drill-down-navigation.md) | Task drill-down navigation | UX |
+| [ADR-005](ADR-005-optional-task-creator-interface.md) | Optional TaskCreator interface for write operations | architecture |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,4 @@
 | [ADR-003](ADR-003-tui-navigation-and-filtering.md) | TUI navigation and filtering model | UX |
 | [ADR-004](ADR-004-task-drill-down-navigation.md) | Task drill-down navigation | UX |
 | [ADR-005](ADR-005-optional-task-creator-interface.md) | Optional TaskCreator interface for write operations | architecture |
+| [ADR-006](ADR-006-extended-create-fields.md) | Extend CreateTaskParams with delivery plan fields | architecture |

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -154,7 +154,7 @@ func checkLatestVersion(version string) tea.Cmd {
 		if err != nil {
 			return versionCheckMsg{}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return versionCheckMsg{}
 		}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -182,13 +182,26 @@ func (m Model) createTask() tea.Cmd {
 			if !ok {
 				continue
 			}
+			// Parse comma-separated tags, trimming whitespace and filtering empties.
+			var tags []string
+			for _, t := range strings.Split(m.formTags, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					tags = append(tags, t)
+				}
+			}
+
 			result, err := creator.CreateTask(ctx, backend.CreateTaskParams{
-				Type:        formTypes[m.formType],
-				Title:       m.formTitle,
-				Description: m.formDesc,
-				ParentID:    m.formParentID(),
-				Iteration:   m.formIteration,
-				Assignee:    m.formAssignee,
+				Type:               formTypes[m.formType],
+				Title:              m.formTitle,
+				Description:        m.formDesc,
+				ParentID:           m.formParentID(),
+				Iteration:          m.formIteration,
+				Assignee:           m.formAssignee,
+				Tags:               tags,
+				StartDate:          m.formStartDate,
+				TargetDate:         m.formTargetDate,
+				AcceptanceCriteria: m.formAcceptCriteria,
 			})
 			if err != nil {
 				return taskCreatedMsg{err: err}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -10,6 +10,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/alcxyz/canopy/internal/backend"
 	"github.com/alcxyz/canopy/internal/config"
 	"github.com/alcxyz/canopy/internal/model"
 )
@@ -21,6 +22,16 @@ type tasksLoadedMsg struct {
 	teamTasks []model.Task
 	doneTasks []model.Task
 	err       error
+}
+
+type taskCreatedMsg struct {
+	task model.Task
+	err  error
+}
+
+type iterationResolvedMsg struct {
+	path string
+	err  error
 }
 
 type tickMsg time.Time
@@ -157,5 +168,53 @@ func checkLatestVersion(version string) tea.Cmd {
 			return versionCheckMsg{}
 		}
 		return versionCheckMsg{latest: payload.TagName}
+	}
+}
+
+// createTask sends a create request to the first backend that supports TaskCreator.
+func (m Model) createTask() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		for _, b := range m.backends {
+			creator, ok := b.(backend.TaskCreator)
+			if !ok {
+				continue
+			}
+			result, err := creator.CreateTask(ctx, backend.CreateTaskParams{
+				Type:        formTypes[m.formType],
+				Title:       m.formTitle,
+				Description: m.formDesc,
+				ParentID:    m.formParentID(),
+				Iteration:   m.formIteration,
+				Assignee:    m.formAssignee,
+			})
+			if err != nil {
+				return taskCreatedMsg{err: err}
+			}
+			return taskCreatedMsg{task: result.Task}
+		}
+
+		return taskCreatedMsg{err: fmt.Errorf("no backend supports creating work items")}
+	}
+}
+
+// resolveIteration fetches the current iteration path for the form.
+func (m Model) resolveIteration() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		for _, b := range m.backends {
+			creator, ok := b.(backend.TaskCreator)
+			if !ok {
+				continue
+			}
+			path, err := creator.CurrentIteration(ctx)
+			return iterationResolvedMsg{path: path, err: err}
+		}
+
+		return iterationResolvedMsg{err: fmt.Errorf("no backend supports iterations")}
 	}
 }

--- a/internal/app/form.go
+++ b/internal/app/form.go
@@ -1,0 +1,255 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/alcxyz/canopy/internal/backend"
+	"github.com/alcxyz/canopy/internal/model"
+)
+
+// formTypes lists the work item types available for creation.
+var formTypes = []model.TaskType{
+	model.TypeFeature,
+	model.TypeUserStory,
+	model.TypeBug,
+	model.TypeTask,
+}
+
+const (
+	formFieldType = iota
+	formFieldTitle
+	formFieldDesc
+	formFieldCount // sentinel
+)
+
+// ── Form key handling ──────────────────────────────────────────────────
+
+func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.formSubmitting {
+		return m, nil // ignore input while submitting
+	}
+
+	key := msg.String()
+
+	switch key {
+	case "esc":
+		m.showForm = false
+		return m, nil
+
+	case "ctrl+s":
+		// Validate and submit.
+		if strings.TrimSpace(m.formTitle) == "" {
+			m.formErr = "title is required"
+			return m, nil
+		}
+		m.formErr = ""
+		m.formSubmitting = true
+		return m, m.createTask()
+
+	case "tab":
+		m.formField = (m.formField + 1) % formFieldCount
+		return m, nil
+
+	case "shift+tab":
+		m.formField = (m.formField - 1 + formFieldCount) % formFieldCount
+		return m, nil
+	}
+
+	// Field-specific handling.
+	switch m.formField {
+	case formFieldType:
+		switch key {
+		case "left", "h":
+			m.formType = (m.formType - 1 + len(formTypes)) % len(formTypes)
+		case "right", "l":
+			m.formType = (m.formType + 1) % len(formTypes)
+		}
+
+	case formFieldTitle:
+		switch key {
+		case "backspace":
+			if len(m.formTitle) > 0 {
+				m.formTitle = m.formTitle[:len(m.formTitle)-1]
+			}
+		case "enter":
+			m.formField = formFieldDesc
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formTitle += string(r)
+			}
+		}
+
+	case formFieldDesc:
+		switch key {
+		case "backspace":
+			if len(m.formDesc) > 0 {
+				m.formDesc = m.formDesc[:len(m.formDesc)-1]
+			}
+		case "enter":
+			m.formDesc += "\n"
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formDesc += string(r)
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// ── Form rendering ─────────────────────────────────────────────────────
+
+func (m Model) renderForm() string {
+	w := min(72, m.width-4)
+	fieldW := w - 20 // label takes ~18 chars + padding
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("  Create work item") + "\n\n")
+
+	// Type selector
+	typeLabel := string(formTypes[m.formType])
+	if m.formField == formFieldType {
+		typeLabel = "< " + typeLabel + " >"
+	}
+	b.WriteString(m.formRow("Type", typeLabel, formFieldType))
+
+	// Title
+	b.WriteString(m.formRow("Title", m.formTextInput(m.formTitle, fieldW, formFieldTitle), formFieldTitle))
+
+	// Description (show up to 3 visible lines)
+	descDisplay := m.formTextInput(m.formDesc, fieldW, formFieldDesc)
+	b.WriteString(m.formRow("Description", descDisplay, formFieldDesc))
+
+	b.WriteString("\n")
+
+	// Read-only info
+	parentLabel := dimStyle.Render("none")
+	if pid := m.formParentID(); pid != "" {
+		pt := m.formParentTitle()
+		parentLabel = dimStyle.Render(fmt.Sprintf("#%s %s", pid, pt))
+	}
+	b.WriteString(m.infoRow("Parent", parentLabel))
+
+	iterLabel := dimStyle.Render("loading...")
+	if m.formIteration != "" {
+		iterLabel = dimStyle.Render(m.formIteration)
+	}
+	b.WriteString(m.infoRow("Sprint", iterLabel))
+
+	assigneeLabel := dimStyle.Render("unassigned")
+	if m.formAssignee != "" {
+		assigneeLabel = dimStyle.Render(m.formAssignee)
+	}
+	b.WriteString(m.infoRow("Assignee", assigneeLabel))
+
+	// Error
+	if m.formErr != "" {
+		b.WriteString("\n")
+		b.WriteString(overdueStyle.Render("  " + m.formErr))
+	}
+
+	if m.formSubmitting {
+		b.WriteString("\n")
+		b.WriteString(statusStyle.Render("  submitting..."))
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(dimStyle.Render("  ctrl+s submit  esc cancel  tab next field"))
+
+	box := borderStyle.Width(w).Render(b.String())
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+func (m Model) formRow(label, value string, field int) string {
+	l := dimStyle.Render(fmt.Sprintf("  %-14s ", label))
+	if m.formField == field {
+		l = filterStyle.Render(fmt.Sprintf("  %-14s ", label))
+	}
+	return l + value + "\n"
+}
+
+func (m Model) infoRow(label, value string) string {
+	return dimStyle.Render(fmt.Sprintf("  %-14s ", label)) + value + "\n"
+}
+
+func (m Model) formTextInput(text string, width, field int) string {
+	// Show last visible line only for simplicity.
+	display := text
+	if lines := strings.Split(text, "\n"); len(lines) > 1 {
+		display = lines[len(lines)-1]
+	}
+	if len([]rune(display)) > width {
+		display = string([]rune(display)[len([]rune(display))-width:])
+	}
+
+	if m.formField == field {
+		return display + filterStyle.Render("█")
+	}
+	if display == "" {
+		return dimStyle.Render("—")
+	}
+	return display
+}
+
+// ── Form helpers ───────────────────────────────────────────────────────
+
+func (m Model) formParentID() string {
+	if len(m.navStack) > 0 {
+		return m.navStack[len(m.navStack)-1].ID
+	}
+	return ""
+}
+
+func (m Model) formParentTitle() string {
+	if len(m.navStack) > 0 {
+		return truncate(m.navStack[len(m.navStack)-1].Title, 40)
+	}
+	return ""
+}
+
+func (m Model) defaultFormTypeIndex() int {
+	if len(m.navStack) > 0 {
+		parent := m.navStack[len(m.navStack)-1]
+		switch parent.Type {
+		case model.TypeEpic:
+			return indexOf(formTypes, model.TypeFeature)
+		case model.TypeFeature:
+			return indexOf(formTypes, model.TypeUserStory)
+		case model.TypeUserStory:
+			return indexOf(formTypes, model.TypeTask)
+		}
+	}
+	return 0 // Feature
+}
+
+func (m Model) defaultAssignee() string {
+	for _, p := range m.cfg.Profiles {
+		if len(p.Team) > 0 {
+			return p.Team[0]
+		}
+	}
+	return ""
+}
+
+// canCreate returns true if any backend supports creating work items.
+func (m Model) canCreate() bool {
+	for _, b := range m.backends {
+		if _, ok := b.(backend.TaskCreator); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(types []model.TaskType, t model.TaskType) int {
+	for i, tt := range types {
+		if tt == t {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/app/form.go
+++ b/internal/app/form.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -23,6 +24,12 @@ const (
 	formFieldType = iota
 	formFieldTitle
 	formFieldDesc
+	formFieldTags
+	formFieldStartDate
+	formFieldTargetDate
+	formFieldAcceptCriteria
+	formFieldIteration
+	formFieldAssignee
 	formFieldCount // sentinel
 )
 
@@ -45,6 +52,18 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if strings.TrimSpace(m.formTitle) == "" {
 			m.formErr = "title is required"
 			return m, nil
+		}
+		if m.formStartDate != "" {
+			if _, err := time.Parse("2006-01-02", m.formStartDate); err != nil {
+				m.formErr = "start date must be YYYY-MM-DD"
+				return m, nil
+			}
+		}
+		if m.formTargetDate != "" {
+			if _, err := time.Parse("2006-01-02", m.formTargetDate); err != nil {
+				m.formErr = "end date must be YYYY-MM-DD"
+				return m, nil
+			}
 		}
 		m.formErr = ""
 		m.formSubmitting = true
@@ -96,6 +115,90 @@ func (m Model) handleFormKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.formDesc += string(r)
 			}
 		}
+
+	case formFieldTags:
+		switch key {
+		case "backspace":
+			if len(m.formTags) > 0 {
+				m.formTags = m.formTags[:len(m.formTags)-1]
+			}
+		case "enter":
+			m.formField = formFieldStartDate
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formTags += string(r)
+			}
+		}
+
+	case formFieldStartDate:
+		switch key {
+		case "backspace":
+			if len(m.formStartDate) > 0 {
+				m.formStartDate = m.formStartDate[:len(m.formStartDate)-1]
+			}
+		case "enter":
+			m.formField = formFieldTargetDate
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formStartDate += string(r)
+			}
+		}
+
+	case formFieldTargetDate:
+		switch key {
+		case "backspace":
+			if len(m.formTargetDate) > 0 {
+				m.formTargetDate = m.formTargetDate[:len(m.formTargetDate)-1]
+			}
+		case "enter":
+			m.formField = formFieldAcceptCriteria
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formTargetDate += string(r)
+			}
+		}
+
+	case formFieldAcceptCriteria:
+		switch key {
+		case "backspace":
+			if len(m.formAcceptCriteria) > 0 {
+				m.formAcceptCriteria = m.formAcceptCriteria[:len(m.formAcceptCriteria)-1]
+			}
+		case "enter":
+			m.formAcceptCriteria += "\n"
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formAcceptCriteria += string(r)
+			}
+		}
+
+	case formFieldIteration:
+		switch key {
+		case "backspace":
+			if len(m.formIteration) > 0 {
+				m.formIteration = m.formIteration[:len(m.formIteration)-1]
+			}
+		case "enter":
+			m.formField = formFieldAssignee
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formIteration += string(r)
+			}
+		}
+
+	case formFieldAssignee:
+		switch key {
+		case "backspace":
+			if len(m.formAssignee) > 0 {
+				m.formAssignee = m.formAssignee[:len(m.formAssignee)-1]
+			}
+		case "enter":
+			m.formField = formFieldCount - 1 // stay on last field
+		default:
+			if r := msg.Runes; len(r) > 0 {
+				m.formAssignee += string(r)
+			}
+		}
 	}
 
 	return m, nil
@@ -125,26 +228,35 @@ func (m Model) renderForm() string {
 	b.WriteString(m.formRow("Description", descDisplay, formFieldDesc))
 
 	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("  -- Delivery plan --") + "\n")
 
-	// Read-only info
+	// Tags
+	b.WriteString(m.formRow("Tags", m.formTextInput(m.formTags, fieldW, formFieldTags), formFieldTags))
+
+	// Start Date
+	b.WriteString(m.formRow("Start Date", m.formDateInput(m.formStartDate, fieldW, formFieldStartDate), formFieldStartDate))
+
+	// End Date
+	b.WriteString(m.formRow("End Date", m.formDateInput(m.formTargetDate, fieldW, formFieldTargetDate), formFieldTargetDate))
+
+	// Acceptance Criteria
+	b.WriteString(m.formRow("Criteria", m.formTextInput(m.formAcceptCriteria, fieldW, formFieldAcceptCriteria), formFieldAcceptCriteria))
+
+	b.WriteString("\n")
+
+	// Sprint (editable)
+	b.WriteString(m.formRow("Sprint", m.formTextInput(m.formIteration, fieldW, formFieldIteration), formFieldIteration))
+
+	// Assignee (editable)
+	b.WriteString(m.formRow("Assignee", m.formTextInput(m.formAssignee, fieldW, formFieldAssignee), formFieldAssignee))
+
+	// Parent (read-only)
 	parentLabel := dimStyle.Render("none")
 	if pid := m.formParentID(); pid != "" {
 		pt := m.formParentTitle()
 		parentLabel = dimStyle.Render(fmt.Sprintf("#%s %s", pid, pt))
 	}
 	b.WriteString(m.infoRow("Parent", parentLabel))
-
-	iterLabel := dimStyle.Render("loading...")
-	if m.formIteration != "" {
-		iterLabel = dimStyle.Render(m.formIteration)
-	}
-	b.WriteString(m.infoRow("Sprint", iterLabel))
-
-	assigneeLabel := dimStyle.Render("unassigned")
-	if m.formAssignee != "" {
-		assigneeLabel = dimStyle.Render(m.formAssignee)
-	}
-	b.WriteString(m.infoRow("Assignee", assigneeLabel))
 
 	// Error
 	if m.formErr != "" {
@@ -193,6 +305,13 @@ func (m Model) formTextInput(text string, width, field int) string {
 		return dimStyle.Render("—")
 	}
 	return display
+}
+
+func (m Model) formDateInput(text string, width, field int) string {
+	if text == "" && m.formField != field {
+		return dimStyle.Render("YYYY-MM-DD")
+	}
+	return m.formTextInput(text, width, field)
 }
 
 // ── Form helpers ───────────────────────────────────────────────────────

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -73,15 +73,19 @@ type Model struct {
 	detailTask model.Task
 
 	// Create-form overlay
-	showForm       bool
-	formField      int    // 0=type, 1=title, 2=description
-	formType       int    // index into formTypes
-	formTitle      string
-	formDesc       string
-	formIteration  string // resolved current iteration path
-	formAssignee   string // default assignee display name
-	formErr        string
-	formSubmitting bool
+	showForm          bool
+	formField         int    // 0=type, 1=title, 2=description, ...
+	formType          int    // index into formTypes
+	formTitle         string
+	formDesc          string
+	formTags          string
+	formStartDate     string
+	formTargetDate    string
+	formAcceptCriteria string
+	formIteration     string // resolved current iteration path
+	formAssignee      string // default assignee display name
+	formErr           string
+	formSubmitting    bool
 
 	// Cache
 	cache        *cache.Store

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -72,6 +72,17 @@ type Model struct {
 	showDetail bool
 	detailTask model.Task
 
+	// Create-form overlay
+	showForm       bool
+	formField      int    // 0=type, 1=title, 2=description
+	formType       int    // index into formTypes
+	formTitle      string
+	formDesc       string
+	formIteration  string // resolved current iteration path
+	formAssignee   string // default assignee display name
+	formErr        string
+	formSubmitting bool
+
 	// Cache
 	cache        *cache.Store
 	tasksLoadedAt time.Time // when the current data was fetched

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -33,7 +33,6 @@ type Model struct {
 
 	// UI state
 	activeTab     tab
-	activeView    int // selected view index on Views tab
 	cursor        int
 	width, height int
 	ready         bool
@@ -42,9 +41,9 @@ type Model struct {
 	statusMsg     string
 
 	// Vim-style gg navigation
-	prevKey    string
-	prevKeyAt  time.Time
-	ggTimeout  time.Duration
+	prevKey   string
+	prevKeyAt time.Time
+	ggTimeout time.Duration
 
 	// Text filter (/ key)
 	filtering   bool
@@ -60,8 +59,8 @@ type Model struct {
 	dateScope string // "this week" by default
 
 	// Date field: which timestamp to use for the date cycle filter.
-	dateField    string   // current field label, e.g. "updated"
-	dateFieldIdx int      // index into dateFields
+	dateField    string // current field label, e.g. "updated"
+	dateFieldIdx int    // index into dateFields
 
 	// Navigation stack for drilling into parent tasks.
 	navStack []model.Task
@@ -73,22 +72,22 @@ type Model struct {
 	detailTask model.Task
 
 	// Create-form overlay
-	showForm          bool
-	formField         int    // 0=type, 1=title, 2=description, ...
-	formType          int    // index into formTypes
-	formTitle         string
-	formDesc          string
-	formTags          string
-	formStartDate     string
-	formTargetDate    string
+	showForm           bool
+	formField          int // 0=type, 1=title, 2=description, ...
+	formType           int // index into formTypes
+	formTitle          string
+	formDesc           string
+	formTags           string
+	formStartDate      string
+	formTargetDate     string
 	formAcceptCriteria string
-	formIteration     string // resolved current iteration path
-	formAssignee      string // default assignee display name
-	formErr           string
-	formSubmitting    bool
+	formIteration      string // resolved current iteration path
+	formAssignee       string // default assignee display name
+	formErr            string
+	formSubmitting     bool
 
 	// Cache
-	cache        *cache.Store
+	cache         *cache.Store
 	tasksLoadedAt time.Time // when the current data was fetched
 
 	// Version update check

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -38,6 +38,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleDetailKey(km)
 		}
 	}
+	if m.showForm {
+		if km, ok := msg.(tea.KeyMsg); ok {
+			return m.handleFormKey(km)
+		}
+	}
 
 	// In text-filter mode, handle input first.
 	if m.filtering {
@@ -61,6 +66,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = fmt.Sprintf("%d my · %d team · %d done",
 				len(m.myTasks), len(m.teamTasks), len(m.doneTasks))
 			m.saveCachedTasks()
+		}
+		return m, nil
+
+	case taskCreatedMsg:
+		m.formSubmitting = false
+		if msg.err != nil {
+			m.formErr = msg.err.Error()
+			return m, nil
+		}
+		m.showForm = false
+		m.statusMsg = fmt.Sprintf("Created %s #%s: %s", msg.task.Type, msg.task.ID, msg.task.Title)
+		m.loading = true
+		return m, m.loadAllTasks()
+
+	case iterationResolvedMsg:
+		if msg.err == nil {
+			m.formIteration = msg.path
 		}
 		return m, nil
 
@@ -224,6 +246,20 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	// Actions
+	case "c":
+		if m.activeTab != tabViews && m.canCreate() {
+			m.showForm = true
+			m.formField = formFieldTitle
+			m.formTitle = ""
+			m.formDesc = ""
+			m.formErr = ""
+			m.formSubmitting = false
+			m.formType = m.defaultFormTypeIndex()
+			m.formAssignee = m.defaultAssignee()
+			m.formIteration = ""
+			return m, m.resolveIteration()
+		}
+
 	case "r":
 		if len(m.backends) > 0 {
 			m.loading = true

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -252,6 +252,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.formField = formFieldTitle
 			m.formTitle = ""
 			m.formDesc = ""
+			m.formTags = ""
+			m.formStartDate = ""
+			m.formTargetDate = ""
+			m.formAcceptCriteria = ""
 			m.formErr = ""
 			m.formSubmitting = false
 			m.formType = m.defaultFormTypeIndex()

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -24,7 +24,7 @@ var (
 		model.StateDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")),
 		model.StateClosed:     lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")),
 	}
-	typeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
+	typeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
 	borderStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("#585b70")).
@@ -268,10 +268,10 @@ func (m Model) renderSplash() string {
 	var info strings.Builder
 	info.WriteString(titleStyle.Render(art))
 	info.WriteString("\n\n")
-	info.WriteString(fmt.Sprintf("  %-14s %s\n", "version", m.version))
-	info.WriteString(fmt.Sprintf("  %-14s %s\n", "config", m.cfgPath))
-	info.WriteString(fmt.Sprintf("  %-14s %s\n", "cache", m.cacheDir))
-	info.WriteString(fmt.Sprintf("  %-14s %s\n", "log", m.logPath))
+	fmt.Fprintf(&info, "  %-14s %s\n", "version", m.version)
+	fmt.Fprintf(&info, "  %-14s %s\n", "config", m.cfgPath)
+	fmt.Fprintf(&info, "  %-14s %s\n", "cache", m.cacheDir)
+	fmt.Fprintf(&info, "  %-14s %s\n", "log", m.logPath)
 	info.WriteString("\n")
 	info.WriteString(dimStyle.Render("  press ! or esc to close"))
 
@@ -354,13 +354,13 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 	// Each column is separated by a single space for readability.
 	// DUE(2) ACT(2) TITLE(flex 60%) PARENT(flex 40%) STATE(12) TYPE(12) ASSIGNEE(18) UPDATED(7) CREATED(7)
 	const sep = " "
-	fixedWidth := 2 + 2 + 12 + 12 + 18 + 7 + 7 // 60 (column widths)
-	separators := 6                               // spaces between 7 columns (parent..created)
+	fixedWidth := 2 + 2 + 12 + 12 + 18 + 7 + 7         // 60 (column widths)
+	separators := 6                                    // spaces between 7 columns (parent..created)
 	flexWidth := m.width - fixedWidth - separators - 2 // 2 for prefix
 	if flexWidth < 30 {
 		flexWidth = 30
 	}
-	titleWidth := flexWidth * 3 / 5   // 60%
+	titleWidth := flexWidth * 3 / 5       // 60%
 	parentWidth := flexWidth - titleWidth // 40%
 
 	hdr := "  " +

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -54,6 +54,9 @@ func (m Model) View() string {
 	if m.showDetail {
 		return m.renderDetail()
 	}
+	if m.showForm {
+		return m.renderForm()
+	}
 
 	var b strings.Builder
 
@@ -226,6 +229,7 @@ Filters:
   esc                      clear all filters
 
 Actions:
+  c                        create work item
   enter                    navigate into task (show subtasks) · select view
   esc / backspace          navigate back · clear filters
   [ / ]                    prev / next sibling task

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -89,7 +89,7 @@ func (a *azureBoards) doRequestCT(ctx context.Context, method, reqURL string, bo
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -291,17 +291,17 @@ func (a *azureBoards) mapWorkItem(wi workItem) model.Task {
 	}
 
 	return model.Task{
-		ID:        strconv.Itoa(wi.ID),
-		Title:     wi.Fields.Title,
-		State:     mapAzureState(wi.Fields.State),
-		Type:      mapAzureType(wi.Fields.WorkItemType),
-		Assignee:  assignee,
-		Labels:    labels,
-		Sprint:    wi.Fields.IterationPath,
-		URL:       webURL,
-		Profile:   a.profile.Name,
-		Backend:   string(config.BackendAzureBoards),
-		ParentID:  parentID,
+		ID:             strconv.Itoa(wi.ID),
+		Title:          wi.Fields.Title,
+		State:          mapAzureState(wi.Fields.State),
+		Type:           mapAzureType(wi.Fields.WorkItemType),
+		Assignee:       assignee,
+		Labels:         labels,
+		Sprint:         wi.Fields.IterationPath,
+		URL:            webURL,
+		Profile:        a.profile.Name,
+		Backend:        string(config.BackendAzureBoards),
+		ParentID:       parentID,
 		CreatedAt:      wi.Fields.CreatedDate,
 		UpdatedAt:      wi.Fields.ChangedDate,
 		StartDate:      wi.Fields.StartDate,
@@ -519,7 +519,7 @@ type workItemsResponse struct {
 }
 
 type workItem struct {
-	ID     int           `json:"id"`
+	ID     int            `json:"id"`
 	Fields workItemFields `json:"fields"`
 	Links  struct {
 		HTML struct {
@@ -529,19 +529,19 @@ type workItem struct {
 }
 
 type workItemFields struct {
-	Title            string     `json:"System.Title"`
-	State            string     `json:"System.State"`
-	WorkItemType     string     `json:"System.WorkItemType"`
-	AssignedTo       assignedTo `json:"System.AssignedTo"`
-	Tags             string     `json:"System.Tags"`
-	IterationPath    string     `json:"System.IterationPath"`
-	Parent           int        `json:"System.Parent"`
-	CreatedDate      time.Time  `json:"System.CreatedDate"`
-	ChangedDate      time.Time  `json:"System.ChangedDate"`
-	StartDate        time.Time  `json:"Microsoft.VSTS.Scheduling.StartDate"`
-	TargetDate       time.Time  `json:"Microsoft.VSTS.Scheduling.TargetDate"`
-	ClosedDate       time.Time  `json:"Microsoft.VSTS.Common.ClosedDate"`
-	StateChangeDate  time.Time  `json:"Microsoft.VSTS.Common.StateChangeDate"`
+	Title           string     `json:"System.Title"`
+	State           string     `json:"System.State"`
+	WorkItemType    string     `json:"System.WorkItemType"`
+	AssignedTo      assignedTo `json:"System.AssignedTo"`
+	Tags            string     `json:"System.Tags"`
+	IterationPath   string     `json:"System.IterationPath"`
+	Parent          int        `json:"System.Parent"`
+	CreatedDate     time.Time  `json:"System.CreatedDate"`
+	ChangedDate     time.Time  `json:"System.ChangedDate"`
+	StartDate       time.Time  `json:"Microsoft.VSTS.Scheduling.StartDate"`
+	TargetDate      time.Time  `json:"Microsoft.VSTS.Scheduling.TargetDate"`
+	ClosedDate      time.Time  `json:"Microsoft.VSTS.Common.ClosedDate"`
+	StateChangeDate time.Time  `json:"Microsoft.VSTS.Common.StateChangeDate"`
 }
 
 type assignedTo struct {

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -1,11 +1,13 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -63,7 +65,11 @@ func getAzToken(ctx context.Context) (string, error) {
 	return result.AccessToken, nil
 }
 
-func (a *azureBoards) doRequest(ctx context.Context, method, url string, body io.Reader) ([]byte, error) {
+func (a *azureBoards) doRequest(ctx context.Context, method, reqURL string, body io.Reader) ([]byte, error) {
+	return a.doRequestCT(ctx, method, reqURL, body, "application/json")
+}
+
+func (a *azureBoards) doRequestCT(ctx context.Context, method, reqURL string, body io.Reader, contentType string) ([]byte, error) {
 	acquire()
 	defer release()
 
@@ -72,12 +78,12 @@ func (a *azureBoards) doRequest(ctx context.Context, method, url string, body io
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 
 	resp, err := a.client.Do(req)
 	if err != nil {
@@ -375,7 +381,96 @@ func (a *azureBoards) ListTeam(_ context.Context) ([]model.TeamMember, error) {
 	return members, nil
 }
 
+// ── CreateTask ──────────────────────────────────────────────────────────
+
+// CurrentIteration returns the current sprint iteration path.
+func (a *azureBoards) CurrentIteration(ctx context.Context) (string, error) {
+	return a.currentIterationPath(ctx)
+}
+
+// CreateTask creates a new work item in Azure DevOps.
+func (a *azureBoards) CreateTask(ctx context.Context, params CreateTaskParams) (CreateTaskResult, error) {
+	azType, ok := typeToAzure[params.Type]
+	if !ok {
+		return CreateTaskResult{}, fmt.Errorf("unsupported work item type: %s", params.Type)
+	}
+
+	ops := []jsonPatchOp{
+		{Op: "add", Path: "/fields/System.Title", Value: params.Title},
+	}
+	if params.Description != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/System.Description",
+			Value: plainTextToHTML(params.Description),
+		})
+	}
+	if params.Iteration != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/System.IterationPath",
+			Value: params.Iteration,
+		})
+	}
+	if params.Assignee != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/System.AssignedTo",
+			Value: params.Assignee,
+		})
+	}
+	if params.ParentID != "" {
+		parentURL := fmt.Sprintf("https://dev.azure.com/%s/_apis/wit/workItems/%s",
+			a.profile.Org, params.ParentID)
+		ops = append(ops, jsonPatchOp{
+			Op:   "add",
+			Path: "/relations/-",
+			Value: relationValue{
+				Rel: "System.LinkTypes.Hierarchy-Reverse",
+				URL: parentURL,
+			},
+		})
+	}
+
+	body, err := json.Marshal(ops)
+	if err != nil {
+		return CreateTaskResult{}, fmt.Errorf("marshalling patch document: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/_apis/wit/workitems/$%s?api-version=7.0",
+		a.baseURL, url.PathEscape(azType))
+
+	data, err := a.doRequestCT(ctx, "PATCH", reqURL, bytes.NewReader(body),
+		"application/json-patch+json")
+	if err != nil {
+		return CreateTaskResult{}, fmt.Errorf("creating work item: %w", err)
+	}
+
+	var wi workItem
+	if err := json.Unmarshal(data, &wi); err != nil {
+		return CreateTaskResult{}, fmt.Errorf("parsing created work item: %w", err)
+	}
+
+	return CreateTaskResult{Task: a.mapWorkItem(wi)}, nil
+}
+
 // ── Azure DevOps response types ─────────────────────────────────────────
+
+type jsonPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+type relationValue struct {
+	Rel string `json:"rel"`
+	URL string `json:"url"`
+}
+
+func plainTextToHTML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\n", "<br>\n")
+	return s
+}
 
 type wiqlResponse struct {
 	WorkItems []struct {

--- a/internal/backend/azure.go
+++ b/internal/backend/azure.go
@@ -388,17 +388,18 @@ func (a *azureBoards) CurrentIteration(ctx context.Context) (string, error) {
 	return a.currentIterationPath(ctx)
 }
 
-// CreateTask creates a new work item in Azure DevOps.
-func (a *azureBoards) CreateTask(ctx context.Context, params CreateTaskParams) (CreateTaskResult, error) {
-	azType, ok := typeToAzure[params.Type]
-	if !ok {
-		return CreateTaskResult{}, fmt.Errorf("unsupported work item type: %s", params.Type)
-	}
-
+// buildCreateOps constructs the JSON patch operations for creating a work item.
+// It is extracted for testability.
+func buildCreateOps(params CreateTaskParams, orgName string) []jsonPatchOp {
 	ops := []jsonPatchOp{
 		{Op: "add", Path: "/fields/System.Title", Value: params.Title},
 	}
-	if params.Description != "" {
+	if params.DescriptionHTML != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/System.Description",
+			Value: params.DescriptionHTML,
+		})
+	} else if params.Description != "" {
 		ops = append(ops, jsonPatchOp{
 			Op: "add", Path: "/fields/System.Description",
 			Value: plainTextToHTML(params.Description),
@@ -418,7 +419,7 @@ func (a *azureBoards) CreateTask(ctx context.Context, params CreateTaskParams) (
 	}
 	if params.ParentID != "" {
 		parentURL := fmt.Sprintf("https://dev.azure.com/%s/_apis/wit/workItems/%s",
-			a.profile.Org, params.ParentID)
+			orgName, params.ParentID)
 		ops = append(ops, jsonPatchOp{
 			Op:   "add",
 			Path: "/relations/-",
@@ -428,6 +429,41 @@ func (a *azureBoards) CreateTask(ctx context.Context, params CreateTaskParams) (
 			},
 		})
 	}
+	if len(params.Tags) > 0 {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/System.Tags",
+			Value: strings.Join(params.Tags, "; "),
+		})
+	}
+	if params.StartDate != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/Microsoft.VSTS.Scheduling.StartDate",
+			Value: params.StartDate,
+		})
+	}
+	if params.TargetDate != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/Microsoft.VSTS.Scheduling.TargetDate",
+			Value: params.TargetDate,
+		})
+	}
+	if params.AcceptanceCriteria != "" {
+		ops = append(ops, jsonPatchOp{
+			Op: "add", Path: "/fields/Microsoft.VSTS.Common.AcceptanceCriteria",
+			Value: plainTextToHTML(params.AcceptanceCriteria),
+		})
+	}
+	return ops
+}
+
+// CreateTask creates a new work item in Azure DevOps.
+func (a *azureBoards) CreateTask(ctx context.Context, params CreateTaskParams) (CreateTaskResult, error) {
+	azType, ok := typeToAzure[params.Type]
+	if !ok {
+		return CreateTaskResult{}, fmt.Errorf("unsupported work item type: %s", params.Type)
+	}
+
+	ops := buildCreateOps(params, a.profile.Org)
 
 	body, err := json.Marshal(ops)
 	if err != nil {

--- a/internal/backend/azure_create_test.go
+++ b/internal/backend/azure_create_test.go
@@ -1,0 +1,261 @@
+package backend
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/alcxyz/canopy/internal/model"
+)
+
+func TestBuildCreateOps_TitleAlwaysPresent(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "My Task",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	if len(ops) == 0 {
+		t.Fatal("expected at least one op")
+	}
+	if ops[0].Path != "/fields/System.Title" {
+		t.Errorf("expected first op path to be System.Title, got %q", ops[0].Path)
+	}
+	if ops[0].Value != "My Task" {
+		t.Errorf("expected title value %q, got %v", "My Task", ops[0].Value)
+	}
+}
+
+func TestBuildCreateOps_TagsProduceSemicolonSeparated(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeFeature,
+		Title: "Feature",
+		Tags:  []string{"Milestone", "CapEx"},
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	var tagsOp *jsonPatchOp
+	for i := range ops {
+		if ops[i].Path == "/fields/System.Tags" {
+			tagsOp = &ops[i]
+			break
+		}
+	}
+	if tagsOp == nil {
+		t.Fatal("expected System.Tags op but none found")
+	}
+	want := "Milestone; CapEx"
+	if tagsOp.Value != want {
+		t.Errorf("expected tags value %q, got %v", want, tagsOp.Value)
+	}
+}
+
+func TestBuildCreateOps_EmptyTagsProduceNoOp(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "Task",
+		Tags:  []string{},
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	for _, op := range ops {
+		if op.Path == "/fields/System.Tags" {
+			t.Errorf("expected no System.Tags op for empty tags, but found one")
+		}
+	}
+}
+
+func TestBuildCreateOps_NilTagsProduceNoOp(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "Task",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	for _, op := range ops {
+		if op.Path == "/fields/System.Tags" {
+			t.Errorf("expected no System.Tags op for nil tags, but found one")
+		}
+	}
+}
+
+func TestBuildCreateOps_DatesProduceCorrectOps(t *testing.T) {
+	params := CreateTaskParams{
+		Type:       model.TypeFeature,
+		Title:      "Feature",
+		StartDate:  "2026-01-01",
+		TargetDate: "2026-03-31",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	paths := make(map[string]interface{})
+	for _, op := range ops {
+		paths[op.Path] = op.Value
+	}
+
+	if v, ok := paths["/fields/Microsoft.VSTS.Scheduling.StartDate"]; !ok {
+		t.Error("expected StartDate op but none found")
+	} else if v != "2026-01-01" {
+		t.Errorf("expected StartDate value %q, got %v", "2026-01-01", v)
+	}
+
+	if v, ok := paths["/fields/Microsoft.VSTS.Scheduling.TargetDate"]; !ok {
+		t.Error("expected TargetDate op but none found")
+	} else if v != "2026-03-31" {
+		t.Errorf("expected TargetDate value %q, got %v", "2026-03-31", v)
+	}
+}
+
+func TestBuildCreateOps_EmptyDatesProduceNoOps(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "Task",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	for _, op := range ops {
+		if op.Path == "/fields/Microsoft.VSTS.Scheduling.StartDate" {
+			t.Errorf("expected no StartDate op for empty start date")
+		}
+		if op.Path == "/fields/Microsoft.VSTS.Scheduling.TargetDate" {
+			t.Errorf("expected no TargetDate op for empty target date")
+		}
+	}
+}
+
+func TestBuildCreateOps_DescriptionHTMLTakesPrecedence(t *testing.T) {
+	params := CreateTaskParams{
+		Type:            model.TypeTask,
+		Title:           "Task",
+		Description:     "plain text",
+		DescriptionHTML: "<p>HTML content</p>",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	var descOp *jsonPatchOp
+	for i := range ops {
+		if ops[i].Path == "/fields/System.Description" {
+			descOp = &ops[i]
+			break
+		}
+	}
+	if descOp == nil {
+		t.Fatal("expected System.Description op but none found")
+	}
+	if descOp.Value != "<p>HTML content</p>" {
+		t.Errorf("expected DescriptionHTML to take precedence, got %v", descOp.Value)
+	}
+}
+
+func TestBuildCreateOps_PlainDescriptionConverted(t *testing.T) {
+	params := CreateTaskParams{
+		Type:        model.TypeTask,
+		Title:       "Task",
+		Description: "line1\nline2",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	var descOp *jsonPatchOp
+	for i := range ops {
+		if ops[i].Path == "/fields/System.Description" {
+			descOp = &ops[i]
+			break
+		}
+	}
+	if descOp == nil {
+		t.Fatal("expected System.Description op but none found")
+	}
+	val, ok := descOp.Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", descOp.Value)
+	}
+	if !strings.Contains(val, "<br>") {
+		t.Errorf("expected plain text to be converted to HTML with <br>, got %q", val)
+	}
+}
+
+func TestBuildCreateOps_AcceptanceCriteriaConverted(t *testing.T) {
+	params := CreateTaskParams{
+		Type:               model.TypeUserStory,
+		Title:              "Story",
+		AcceptanceCriteria: "Given X\nWhen Y\nThen Z",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	var acOp *jsonPatchOp
+	for i := range ops {
+		if ops[i].Path == "/fields/Microsoft.VSTS.Common.AcceptanceCriteria" {
+			acOp = &ops[i]
+			break
+		}
+	}
+	if acOp == nil {
+		t.Fatal("expected AcceptanceCriteria op but none found")
+	}
+	val, ok := acOp.Value.(string)
+	if !ok {
+		t.Fatalf("expected string value, got %T", acOp.Value)
+	}
+	if !strings.Contains(val, "<br>") {
+		t.Errorf("expected acceptance criteria to be HTML-converted, got %q", val)
+	}
+}
+
+func TestBuildCreateOps_EmptyAcceptanceCriteriaProducesNoOp(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "Task",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	for _, op := range ops {
+		if op.Path == "/fields/Microsoft.VSTS.Common.AcceptanceCriteria" {
+			t.Errorf("expected no AcceptanceCriteria op for empty criteria")
+		}
+	}
+}
+
+func TestBuildCreateOps_ParentIDProducesRelationOp(t *testing.T) {
+	params := CreateTaskParams{
+		Type:     model.TypeTask,
+		Title:    "Task",
+		ParentID: "42",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	var relOp *jsonPatchOp
+	for i := range ops {
+		if ops[i].Path == "/relations/-" {
+			relOp = &ops[i]
+			break
+		}
+	}
+	if relOp == nil {
+		t.Fatal("expected relations op but none found")
+	}
+	rv, ok := relOp.Value.(relationValue)
+	if !ok {
+		t.Fatalf("expected relationValue, got %T", relOp.Value)
+	}
+	if rv.Rel != "System.LinkTypes.Hierarchy-Reverse" {
+		t.Errorf("unexpected rel type: %q", rv.Rel)
+	}
+	wantURL := fmt.Sprintf("https://dev.azure.com/myorg/_apis/wit/workItems/42")
+	if rv.URL != wantURL {
+		t.Errorf("expected URL %q, got %q", wantURL, rv.URL)
+	}
+}
+
+func TestBuildCreateOps_EmptyParentIDProducesNoRelationOp(t *testing.T) {
+	params := CreateTaskParams{
+		Type:  model.TypeTask,
+		Title: "Task",
+	}
+	ops := buildCreateOps(params, "myorg")
+
+	for _, op := range ops {
+		if op.Path == "/relations/-" {
+			t.Errorf("expected no relation op for empty ParentID")
+		}
+	}
+}

--- a/internal/backend/azure_create_test.go
+++ b/internal/backend/azure_create_test.go
@@ -1,7 +1,6 @@
 package backend
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -240,7 +239,7 @@ func TestBuildCreateOps_ParentIDProducesRelationOp(t *testing.T) {
 	if rv.Rel != "System.LinkTypes.Hierarchy-Reverse" {
 		t.Errorf("unexpected rel type: %q", rv.Rel)
 	}
-	wantURL := fmt.Sprintf("https://dev.azure.com/myorg/_apis/wit/workItems/42")
+	wantURL := "https://dev.azure.com/myorg/_apis/wit/workItems/42"
 	if rv.URL != wantURL {
 		t.Errorf("expected URL %q, got %q", wantURL, rv.URL)
 	}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -23,6 +23,29 @@ type Backend interface {
 	ListTeam(ctx context.Context) ([]model.TeamMember, error)
 }
 
+// CreateTaskParams holds the inputs for creating a new work item.
+type CreateTaskParams struct {
+	Type        model.TaskType
+	Title       string
+	Description string // plain text; backends convert to their native format
+	ParentID    string // optional parent work item ID
+	Iteration   string // iteration/sprint path; empty = backend default
+	Assignee    string // display name or email; empty = unassigned
+}
+
+// CreateTaskResult holds the outcome of a successful creation.
+type CreateTaskResult struct {
+	Task model.Task
+}
+
+// TaskCreator is an optional interface for backends that support creating
+// work items. Check with: if creator, ok := b.(TaskCreator); ok { ... }
+type TaskCreator interface {
+	CreateTask(ctx context.Context, params CreateTaskParams) (CreateTaskResult, error)
+	// CurrentIteration returns the current sprint/iteration path.
+	CurrentIteration(ctx context.Context) (string, error)
+}
+
 // New creates a Backend from a profile configuration.
 func New(profile config.Profile) (Backend, error) {
 	switch profile.Backend {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -31,6 +31,12 @@ type CreateTaskParams struct {
 	ParentID    string // optional parent work item ID
 	Iteration   string // iteration/sprint path; empty = backend default
 	Assignee    string // display name or email; empty = unassigned
+
+	DescriptionHTML    string   // pre-formatted HTML; takes precedence over Description when set
+	Tags               []string // backend-agnostic labels; Azure joins with "; "
+	StartDate          string   // YYYY-MM-DD; empty = not set
+	TargetDate         string   // YYYY-MM-DD; empty = not set
+	AcceptanceCriteria string   // plain text; backends convert to native format
 }
 
 // CreateTaskResult holds the outcome of a successful creation.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,10 @@ const (
 // Filter defines criteria for selecting tasks in a view.
 type Filter struct {
 	UpdatedSince string   `yaml:"updated_since"` // relative: "last_week", "last_month", etc.
-	Types        []string `yaml:"types"`          // feature, bug, user-story, task, etc.
-	Status       []string `yaml:"status"`         // done, in-progress, in-review, todo, etc.
-	Sprint       string   `yaml:"sprint"`         // "current", "previous", or sprint name
-	Assignee     string   `yaml:"assignee"`       // "me", or a team member name/email
+	Types        []string `yaml:"types"`         // feature, bug, user-story, task, etc.
+	Status       []string `yaml:"status"`        // done, in-progress, in-review, todo, etc.
+	Sprint       string   `yaml:"sprint"`        // "current", "previous", or sprint name
+	Assignee     string   `yaml:"assignee"`      // "me", or a team member name/email
 	Labels       []string `yaml:"labels"`
 }
 
@@ -66,7 +66,7 @@ type Profile struct {
 type Config struct {
 	Profiles    []Profile `yaml:"profiles"`
 	Views       []View    `yaml:"views"`
-	Tags        []string  `yaml:"tags"`        // preset tags for the t cycle filter
+	Tags        []string  `yaml:"tags"` // preset tags for the t cycle filter
 	RefreshSecs int       `yaml:"refresh_secs"`
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -27,18 +27,18 @@ const (
 
 // Task is the unified work item across all backends.
 type Task struct {
-	ID          string
-	Title       string
-	State       TaskState
-	Type        TaskType
-	Assignee    string
-	Labels      []string
-	Sprint      string
-	URL         string // web URL to open in browser
-	Profile     string // which profile this came from
-	Backend     string // backend type for display
-	ParentID    string // parent work item ID (if any)
-	ParentTitle string // resolved parent title
+	ID             string
+	Title          string
+	State          TaskState
+	Type           TaskType
+	Assignee       string
+	Labels         []string
+	Sprint         string
+	URL            string // web URL to open in browser
+	Profile        string // which profile this came from
+	Backend        string // backend type for display
+	ParentID       string // parent work item ID (if any)
+	ParentTitle    string // resolved parent title
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	StartDate      time.Time


### PR DESCRIPTION
## Summary
- Add CI workflow matching grove's setup: gofmt, golangci-lint v2, go vet, build, test with race detector
- Runs Check job on dev push (fast feedback) and PRs to main
- Fix all existing lint issues (errcheck, staticcheck QF1012, unused field, unnecessary fmt.Sprintf)
- Opt into Node.js 24 for GitHub Actions

## Test plan
- [x] CI passes on `dev` push
- [ ] CI passes on this PR