### PR TITLE
feat: align canopy with grove project structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,77 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+  release:
+    name: Release
+    needs: check
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
+
+      - name: Validate release archives
+        run: |
+          set -euo pipefail
+          for tarball in dist/*.tar.gz; do
+            echo "==> Checking $tarball"
+
+            contents=$(tar tzf "$tarball")
+
+            # No '.' directory entry (breaks Homebrew extraction)
+            if echo "$contents" | grep -qx '\./$\|^\.'; then
+              echo "FAIL: $tarball contains a '.' directory entry"
+              echo "$contents" | head -20
+              exit 1
+            fi
+
+            # Expected files present
+            for f in canopy README.md LICENSE config.example.yaml; do
+              if ! echo "$contents" | grep -q "$f"; then
+                echo "FAIL: $tarball missing $f"
+                echo "$contents"
+                exit 1
+              fi
+            done
+
+            echo "  OK"
+          done
+
+      - name: Auto-tag release
+        id: tag
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          VERSION="v$(cat VERSION)"
+          if git tag -l "$VERSION" | grep -q . || git ls-remote --tags origin "$VERSION" | grep -q .; then
+            echo "Tag $VERSION already exists, skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Creating tag $VERSION"
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run GoReleaser
+        if: steps.tag.outputs.created == 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,65 @@
+version: 2
+
+project_name: canopy
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/canopy
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - id: canopy
+    name_template: "canopy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    files:
+      - README.md
+      - LICENSE
+      - src: cmd/canopy/config.example.yaml
+        strip_parent: true
+
+checksum:
+  name_template: "canopy_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: alcxyz
+    name: canopy
+  draft: false
+  prerelease: auto
+
+brews:
+  - name: canopy
+    repository:
+      owner: alcxyz
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/alcxyz/canopy
+    description: "Terminal UI for tracking tasks across work management backends"
+    license: MIT
+    install: |
+      bin.install "canopy"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to canopy
+
+## Development setup
+
+Prerequisites: Go 1.26+, [`az` CLI](https://learn.microsoft.com/en-us/cli/azure/) (canopy uses it for Azure Boards authentication)
+
+```bash
+git clone https://github.com/alcxyz/canopy.git
+cd canopy
+go build ./cmd/canopy
+```
+
+## Running tests
+
+```bash
+go test ./...
+```
+
+## Vetting
+
+CI runs `go vet`. Run it locally to catch issues before pushing:
+
+```bash
+go vet ./...
+```
+
+## Project structure
+
+- `cmd/canopy/` -- entry point, config example
+- `cmd/smoke/` -- headless backend smoke test
+- `internal/app/` -- core TUI application (commands, filtering, update, view, form)
+- `internal/backend/` -- multi-backend abstraction (Azure Boards, GitHub Issues, Jira, Linear)
+- `internal/cache/` -- task caching
+- `internal/config/` -- YAML config loading
+- `internal/model/` -- task model
+- `internal/ui/` -- styles
+
+## Making changes
+
+1. Fork the repo and create a branch from `dev`
+2. Make your changes
+3. Add or update tests as needed
+4. Run `go test ./...` and `go vet ./...`
+5. Open a pull request against `dev`
+
+CI runs build, vet, and tests. All checks must pass before merging.
+
+## Commit messages
+
+Use conventional-ish prefixes to keep history scannable:
+
+- `feat:` new feature
+- `fix:` bug fix
+- `docs:` documentation only
+- `chore:` maintenance, CI, dependencies
+- `refactor:` code changes that don't add features or fix bugs
+
+## Releasing
+
+Releases are automated via [GoReleaser](https://goreleaser.com/) and GitHub Actions. The `VERSION` file is the single source of truth.
+
+To cut a release:
+
+1. Bump the `VERSION` file on `dev`
+2. Merge `dev` into `main`
+3. CI automatically creates the git tag and runs GoReleaser
+
+This builds binaries for linux/darwin x amd64/arm64, creates a GitHub release with changelog, and updates the [Homebrew tap](https://github.com/alcxyz/homebrew-tap).
+
+### Version numbering
+
+Follow [semver](https://semver.org/):
+
+- **Patch** (`v0.5.x`): bug fixes, minor tweaks
+- **Minor** (`v0.x.0`): new features, non-breaking changes
+- **Major** (`vx.0.0`): breaking changes to config format, CLI flags, or behavior
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/cmd/canopy/main.go
+++ b/cmd/canopy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -12,36 +13,77 @@ import (
 	"github.com/alcxyz/canopy/internal/config"
 )
 
+// version is injected at build time via -ldflags "-X main.version=<tag>".
+// Falls back to "dev" for local builds.
+var version = "dev"
+
 //go:embed config.example.yaml
 var exampleConfig []byte
 
+func setupLog() (string, func()) {
+	logPath := config.LogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return "", func() {}
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", func() {}
+	}
+	log.SetOutput(f)
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	return logPath, func() { _ = f.Close() }
+}
+
 func main() {
+	logPath, closeLog := setupLog()
+	defer closeLog()
+
+	// First-run bootstrap: write the example config to the XDG path so the
+	// user has a real file to edit rather than relying on compiled defaults.
 	if config.NeedsBootstrap() {
-		p, err := config.BootstrapXDG(exampleConfig)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error writing config: %v\n", err)
-			os.Exit(1)
+		if p, err := config.BootstrapXDG(exampleConfig); err != nil {
+			log.Printf("bootstrap config: %v", err)
+		} else {
+			log.Printf("bootstrapped config at %s", p)
 		}
-		fmt.Printf("Wrote example config to %s — edit it and re-run canopy.\n", p)
-		os.Exit(0)
+	}
+
+	// Help flag — print usage and exit.
+	if len(os.Args) > 1 && (os.Args[1] == "-h" || os.Args[1] == "--help" || os.Args[1] == "-help" || os.Args[1] == "help" || os.Args[1] == "h") {
+		fmt.Print(`canopy — terminal UI for tracking tasks across work management backends
+
+Usage:
+  canopy                    launch the TUI
+  canopy -v, --version      print version and paths
+  canopy -h, --help         show this help
+
+Navigation:
+  1-4         switch tabs (My Tasks, Team, Done, Views)
+  h/l         previous/next tab
+  j/k         move cursor down/up
+  enter       open detail view
+  /           text filter
+  ?           keybinding reference
+  q           quit
+
+Config: ` + config.ConfigPath() + "\n")
+		return
+	}
+
+	// Version flag — print and exit before any TUI setup.
+	if len(os.Args) > 1 && (os.Args[1] == "-v" || os.Args[1] == "--version" || os.Args[1] == "-version" || os.Args[1] == "version" || os.Args[1] == "v") {
+		fmt.Printf("canopy %s\nconfig: %s\ncache:  %s\nlog:    %s\n",
+			version, config.ConfigPath(), config.CacheDir(), config.LogPath())
+		return
 	}
 
 	cfg := config.Load()
 
-	logDir := filepath.Dir(config.LogPath())
-	_ = os.MkdirAll(logDir, 0o755)
-	logFile, err := os.OpenFile(config.LogPath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "cannot open log: %v\n", err)
-		os.Exit(1)
-	}
-	defer func() { _ = logFile.Close() }()
-
 	p := tea.NewProgram(
 		app.New(app.Options{
 			Cfg:      cfg,
-			Version:  "0.1.0",
-			LogPath:  config.LogPath(),
+			Version:  version,
+			LogPath:  logPath,
 			CfgPath:  config.ConfigPath(),
 			CacheDir: config.CacheDir(),
 		}),

--- a/internal/app/form.go
+++ b/internal/app/form.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alcxyz/canopy/internal/backend"
 	"github.com/alcxyz/canopy/internal/model"
+	"github.com/alcxyz/canopy/internal/ui"
 )
 
 // formTypes lists the work item types available for creation.
@@ -211,7 +212,7 @@ func (m Model) renderForm() string {
 	fieldW := w - 20 // label takes ~18 chars + padding
 
 	var b strings.Builder
-	b.WriteString(titleStyle.Render("  Create work item") + "\n\n")
+	b.WriteString(ui.TitleStyle.Render("  Create work item") + "\n\n")
 
 	// Type selector
 	typeLabel := string(formTypes[m.formType])
@@ -228,7 +229,7 @@ func (m Model) renderForm() string {
 	b.WriteString(m.formRow("Description", descDisplay, formFieldDesc))
 
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  -- Delivery plan --") + "\n")
+	b.WriteString(ui.DimStyle.Render("  -- Delivery plan --") + "\n")
 
 	// Tags
 	b.WriteString(m.formRow("Tags", m.formTextInput(m.formTags, fieldW, formFieldTags), formFieldTags))
@@ -251,41 +252,41 @@ func (m Model) renderForm() string {
 	b.WriteString(m.formRow("Assignee", m.formTextInput(m.formAssignee, fieldW, formFieldAssignee), formFieldAssignee))
 
 	// Parent (read-only)
-	parentLabel := dimStyle.Render("none")
+	parentLabel := ui.DimStyle.Render("none")
 	if pid := m.formParentID(); pid != "" {
 		pt := m.formParentTitle()
-		parentLabel = dimStyle.Render(fmt.Sprintf("#%s %s", pid, pt))
+		parentLabel = ui.DimStyle.Render(fmt.Sprintf("#%s %s", pid, pt))
 	}
 	b.WriteString(m.infoRow("Parent", parentLabel))
 
 	// Error
 	if m.formErr != "" {
 		b.WriteString("\n")
-		b.WriteString(overdueStyle.Render("  " + m.formErr))
+		b.WriteString(ui.OverdueStyle.Render("  " + m.formErr))
 	}
 
 	if m.formSubmitting {
 		b.WriteString("\n")
-		b.WriteString(statusStyle.Render("  submitting..."))
+		b.WriteString(ui.StatusStyle.Render("  submitting..."))
 	}
 
 	b.WriteString("\n\n")
-	b.WriteString(dimStyle.Render("  ctrl+s submit  esc cancel  tab next field"))
+	b.WriteString(ui.DimStyle.Render("  ctrl+s submit  esc cancel  tab next field"))
 
-	box := borderStyle.Width(w).Render(b.String())
+	box := ui.BorderStyle.Width(w).Render(b.String())
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
 func (m Model) formRow(label, value string, field int) string {
-	l := dimStyle.Render(fmt.Sprintf("  %-14s ", label))
+	l := ui.DimStyle.Render(fmt.Sprintf("  %-14s ", label))
 	if m.formField == field {
-		l = filterStyle.Render(fmt.Sprintf("  %-14s ", label))
+		l = ui.FilterStyle.Render(fmt.Sprintf("  %-14s ", label))
 	}
 	return l + value + "\n"
 }
 
 func (m Model) infoRow(label, value string) string {
-	return dimStyle.Render(fmt.Sprintf("  %-14s ", label)) + value + "\n"
+	return ui.DimStyle.Render(fmt.Sprintf("  %-14s ", label)) + value + "\n"
 }
 
 func (m Model) formTextInput(text string, width, field int) string {
@@ -299,17 +300,17 @@ func (m Model) formTextInput(text string, width, field int) string {
 	}
 
 	if m.formField == field {
-		return display + filterStyle.Render("█")
+		return display + ui.FilterStyle.Render("█")
 	}
 	if display == "" {
-		return dimStyle.Render("—")
+		return ui.DimStyle.Render("—")
 	}
 	return display
 }
 
 func (m Model) formDateInput(text string, width, field int) string {
 	if text == "" && m.formField != field {
-		return dimStyle.Render("YYYY-MM-DD")
+		return ui.DimStyle.Render("YYYY-MM-DD")
 	}
 	return m.formTextInput(text, width, field)
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -148,6 +148,10 @@ func New(o Options) Model {
 	if cs, err := cache.New(o.CacheDir, o.Cfg.CacheKey()); err == nil {
 		m.cache = cs
 		m.loadCachedTasks()
+		st := cs.LoadUIState()
+		if st.ActiveTab >= int(tabMyTasks) && st.ActiveTab <= int(tabViews) {
+			m.activeTab = tab(st.ActiveTab)
+		}
 	}
 
 	return m
@@ -189,5 +193,17 @@ func (m Model) saveCachedTasks() {
 		_ = cs.Set("my_tasks", cachedTasks{Tasks: my})
 		_ = cs.Set("team_tasks", cachedTasks{Tasks: team})
 		_ = cs.Set("done_tasks", cachedTasks{Tasks: done})
+	}()
+}
+
+// saveState persists the current UI state (active tab) to disk asynchronously.
+func (m Model) saveState() {
+	if m.cache == nil {
+		return
+	}
+	cs := m.cache
+	st := cache.UIState{ActiveTab: int(m.activeTab)}
+	go func() {
+		_ = cs.SaveUIState(st)
 	}()
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -152,6 +152,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.navStack = nil
 			m.clearCycleFilter()
 			m.filterQuery = ""
+			go m.saveState()
 		}
 	case "l":
 		if m.activeTab < tabViews {
@@ -160,6 +161,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.navStack = nil
 			m.clearCycleFilter()
 			m.filterQuery = ""
+			go m.saveState()
 		}
 	case "1":
 		m.activeTab = tabMyTasks
@@ -167,24 +169,28 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
+		go m.saveState()
 	case "2":
 		m.activeTab = tabTeam
 		m.cursor = 0
 		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
+		go m.saveState()
 	case "3":
 		m.activeTab = tabDone
 		m.cursor = 0
 		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
+		go m.saveState()
 	case "4":
 		m.activeTab = tabViews
 		m.cursor = 0
 		m.navStack = nil
 		m.clearCycleFilter()
 		m.filterQuery = ""
+		go m.saveState()
 
 	// List navigation
 	case "j", "down":

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -6,38 +6,17 @@ import (
 	"time"
 
 	"github.com/alcxyz/canopy/internal/model"
+	"github.com/alcxyz/canopy/internal/ui"
 	"github.com/charmbracelet/lipgloss"
 )
 
-var (
-	tabStyle       = lipgloss.NewStyle().Padding(0, 2)
-	activeTabStyle = lipgloss.NewStyle().Padding(0, 2).Bold(true).Foreground(lipgloss.Color("#cba6f7"))
-	titleStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#cba6f7"))
-	dimStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086"))
-	filterStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af"))
-	statusStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#9399b2"))
-	countStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa"))
-	stateColors    = map[model.TaskState]lipgloss.Style{
-		model.StateTodo:       lipgloss.NewStyle().Foreground(lipgloss.Color("#585b70")),
-		model.StateInProgress: lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")),
-		model.StateInReview:   lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")),
-		model.StateDone:       lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")),
-		model.StateClosed:     lipgloss.NewStyle().Foreground(lipgloss.Color("#6c7086")),
-	}
-	typeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#cdd6f4"))
-	borderStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#585b70")).
-			Padding(1, 2)
-
-	// Indicator styles (grove pattern)
-	overdueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f38ba8")) // red
-	dueSoonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")) // yellow
-	freshStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#a6e3a1")) // green
-	recentStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#89b4fa")) // blue
-	agingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#f9e2af")) // yellow
-	staleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#f38ba8")) // red
-)
+var stateColors = map[model.TaskState]lipgloss.Style{
+	model.StateTodo:       ui.StateTodoColor,
+	model.StateInProgress: ui.StateInProgressColor,
+	model.StateInReview:   ui.StateInReviewColor,
+	model.StateDone:       ui.StateDoneColor,
+	model.StateClosed:     ui.StateClosedColor,
+}
 
 func (m Model) View() string {
 	if !m.ready {
@@ -64,9 +43,9 @@ func (m Model) View() string {
 	var tabs []string
 	for i, name := range tabNames {
 		if tab(i) == m.activeTab {
-			tabs = append(tabs, activeTabStyle.Render(name))
+			tabs = append(tabs, ui.ActiveTabStyle.Render(name))
 		} else {
-			tabs = append(tabs, tabStyle.Render(name))
+			tabs = append(tabs, ui.TabStyle.Render(name))
 		}
 	}
 	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, tabs...))
@@ -74,7 +53,7 @@ func (m Model) View() string {
 	// Active filter indicator next to tabs
 	if indicator := m.filterIndicator(); indicator != "" {
 		b.WriteString("  ")
-		b.WriteString(filterStyle.Render(indicator))
+		b.WriteString(ui.FilterStyle.Render(indicator))
 	}
 
 	b.WriteString("\n")
@@ -82,11 +61,11 @@ func (m Model) View() string {
 	// Breadcrumb (when navigated into a task)
 	if len(m.navStack) > 0 {
 		tabName := strings.SplitN(tabNames[m.activeTab], " [", 2)[0]
-		crumbs := []string{dimStyle.Render(tabName)}
+		crumbs := []string{ui.DimStyle.Render(tabName)}
 		for _, t := range m.navStack {
-			crumbs = append(crumbs, titleStyle.Render(truncate(t.Title, 40)))
+			crumbs = append(crumbs, ui.TitleStyle.Render(truncate(t.Title, 40)))
 		}
-		b.WriteString("  " + strings.Join(crumbs, dimStyle.Render(" › ")))
+		b.WriteString("  " + strings.Join(crumbs, ui.DimStyle.Render(" › ")))
 		b.WriteString("\n")
 	}
 
@@ -95,7 +74,7 @@ func (m Model) View() string {
 
 	// Text filter input
 	if m.filtering {
-		b.WriteString(filterStyle.Render("  / " + m.filterQuery + "█"))
+		b.WriteString(ui.FilterStyle.Render("  / " + m.filterQuery + "█"))
 		b.WriteString("\n")
 	}
 
@@ -126,19 +105,19 @@ func (m Model) renderStatusBar() string {
 	if msg == "" {
 		msg = m.defaultStatusMsg()
 	}
-	return statusStyle.Render(msg)
+	return ui.StatusStyle.Render(msg)
 }
 
 func (m Model) defaultStatusMsg() string {
 	var parts []string
 	if n := len(m.myTasks); n > 0 {
-		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" my")
+		parts = append(parts, ui.CountStyle.Render(fmt.Sprintf("%d", n))+" my")
 	}
 	if n := len(m.teamTasks); n > 0 {
-		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" team")
+		parts = append(parts, ui.CountStyle.Render(fmt.Sprintf("%d", n))+" team")
 	}
 	if n := len(m.doneTasks); n > 0 {
-		parts = append(parts, countStyle.Render(fmt.Sprintf("%d", n))+" done")
+		parts = append(parts, ui.CountStyle.Render(fmt.Sprintf("%d", n))+" done")
 	}
 	if len(parts) == 0 {
 		return ""
@@ -149,7 +128,7 @@ func (m Model) defaultStatusMsg() string {
 // ── Info bar ────────────────────────────────────────────────────────────
 
 func (m Model) renderInfoBar() string {
-	return dimStyle.Render(m.infoBarText())
+	return ui.DimStyle.Render(m.infoBarText())
 }
 
 func (m Model) infoBarText() string {
@@ -245,9 +224,9 @@ Indicators:
   ⏱  due        ! overdue · ● due this week · ○ has date · — no date
   ↻  activity   ● green today · ● blue this week · ● yellow this month · ● red stale`
 
-	box := borderStyle.Width(min(72, m.width-4)).Render(
-		titleStyle.Render("canopy — help") + "\n\n" + help + "\n\n" +
-			dimStyle.Render("press ? or esc to close"),
+	box := ui.BorderStyle.Width(min(72, m.width-4)).Render(
+		ui.TitleStyle.Render("canopy — help") + "\n\n" + help + "\n\n" +
+			ui.DimStyle.Render("press ? or esc to close"),
 	)
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
@@ -266,16 +245,16 @@ func (m Model) renderSplash() string {
   canopy`
 
 	var info strings.Builder
-	info.WriteString(titleStyle.Render(art))
+	info.WriteString(ui.TitleStyle.Render(art))
 	info.WriteString("\n\n")
 	fmt.Fprintf(&info, "  %-14s %s\n", "version", m.version)
 	fmt.Fprintf(&info, "  %-14s %s\n", "config", m.cfgPath)
 	fmt.Fprintf(&info, "  %-14s %s\n", "cache", m.cacheDir)
 	fmt.Fprintf(&info, "  %-14s %s\n", "log", m.logPath)
 	info.WriteString("\n")
-	info.WriteString(dimStyle.Render("  press ! or esc to close"))
+	info.WriteString(ui.DimStyle.Render("  press ! or esc to close"))
 
-	box := borderStyle.Width(min(64, m.width-4)).Render(info.String())
+	box := ui.BorderStyle.Width(min(64, m.width-4)).Render(info.String())
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
@@ -287,15 +266,15 @@ func (m Model) renderDetail() string {
 
 	row := func(label, value string) string {
 		if value == "" {
-			value = dimStyle.Render("—")
+			value = ui.DimStyle.Render("—")
 		}
-		return fmt.Sprintf("  %-16s %s\n", dimStyle.Render(label), value)
+		return fmt.Sprintf("  %-16s %s\n", ui.DimStyle.Render(label), value)
 	}
 
 	ss := stateColors[t.State]
 
 	var b strings.Builder
-	b.WriteString(titleStyle.Render("  "+t.Title) + "\n\n")
+	b.WriteString(ui.TitleStyle.Render("  "+t.Title) + "\n\n")
 	b.WriteString(row("ID", t.ID))
 	b.WriteString(row("State", ss.Render(string(t.State))))
 	b.WriteString(row("Type", string(t.Type)))
@@ -316,12 +295,12 @@ func (m Model) renderDetail() string {
 	b.WriteString(row("State changed", fmtTime(t.StateChangedAt)))
 	if t.URL != "" {
 		b.WriteString("\n")
-		b.WriteString(row("URL", dimStyle.Render(t.URL)))
+		b.WriteString(row("URL", ui.DimStyle.Render(t.URL)))
 	}
 	b.WriteString("\n")
-	b.WriteString(dimStyle.Render("  [/] prev/next · enter navigate in · o open · space copy URL · esc close"))
+	b.WriteString(ui.DimStyle.Render("  [/] prev/next · enter navigate in · o open · space copy URL · esc close"))
 
-	box := borderStyle.Width(w).Render(b.String())
+	box := ui.BorderStyle.Width(w).Render(b.String())
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }
 
@@ -329,7 +308,7 @@ func fmtTime(t time.Time) string {
 	if t.IsZero() {
 		return ""
 	}
-	return t.Format("2006-01-02 15:04") + dimStyle.Render(" ("+timeAgo(t)+")")
+	return t.Format("2006-01-02 15:04") + ui.DimStyle.Render(" ("+timeAgo(t)+")")
 }
 
 // ── Task list rendering ─────────────────────────────────────────────────
@@ -337,15 +316,15 @@ func fmtTime(t time.Time) string {
 func (m Model) renderTaskList(tasks []model.Task) string {
 	if len(tasks) == 0 {
 		if len(m.backends) == 0 {
-			return dimStyle.Render("  No backends configured. Edit ~/.config/canopy/config.yaml")
+			return ui.DimStyle.Render("  No backends configured. Edit ~/.config/canopy/config.yaml")
 		}
 		if m.err != nil {
-			return dimStyle.Render(fmt.Sprintf("  Error: %v", m.err))
+			return ui.DimStyle.Render(fmt.Sprintf("  Error: %v", m.err))
 		}
 		if len(m.navStack) > 0 {
-			return dimStyle.Render("  No subtasks.")
+			return ui.DimStyle.Render("  No subtasks.")
 		}
-		return dimStyle.Render("  No tasks found.")
+		return ui.DimStyle.Render("  No tasks found.")
 	}
 
 	var b strings.Builder
@@ -372,7 +351,7 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 		cell("ASSIGNEE", 18) + sep +
 		cell("UPDATED", 7) + sep +
 		cell("CREATED", 7)
-	b.WriteString(dimStyle.Render(hdr))
+	b.WriteString(ui.DimStyle.Render(hdr))
 	b.WriteString("\n")
 
 	for i, t := range tasks {
@@ -384,13 +363,13 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 		due := cell(dueIndicator(t), 2)
 		act := cell(activityIndicator(t), 2)
 		title := cell(truncate(t.Title, titleWidth), titleWidth)
-		parent := dimStyle.Render(cell(truncate(t.ParentTitle, parentWidth), parentWidth))
+		parent := ui.DimStyle.Render(cell(truncate(t.ParentTitle, parentWidth), parentWidth))
 		ss := stateColors[t.State]
 		state := ss.Render(cell(string(t.State), 12))
-		typ := typeStyle.Render(cell(string(t.Type), 12))
-		assignee := dimStyle.Render(cell(truncate(t.Assignee, 18), 18))
-		updated := dimStyle.Render(cell(timeAgo(t.UpdatedAt), 7))
-		created := dimStyle.Render(cell(timeAgo(t.CreatedAt), 7))
+		typ := ui.TypeStyle.Render(cell(string(t.Type), 12))
+		assignee := ui.DimStyle.Render(cell(truncate(t.Assignee, 18), 18))
+		updated := ui.DimStyle.Render(cell(timeAgo(t.UpdatedAt), 7))
+		created := ui.DimStyle.Render(cell(timeAgo(t.CreatedAt), 7))
 
 		line := prefix + due + act + title + sep +
 			parent + sep + state + sep + typ + sep +
@@ -406,7 +385,7 @@ func (m Model) renderTaskList(tasks []model.Task) string {
 
 func (m Model) renderViews() string {
 	if len(m.cfg.Views) == 0 {
-		return dimStyle.Render("  No views configured. Add views to your config.yaml")
+		return ui.DimStyle.Render("  No views configured. Add views to your config.yaml")
 	}
 
 	var b strings.Builder
@@ -417,10 +396,10 @@ func (m Model) renderViews() string {
 		}
 		desc := ""
 		if v.Description != "" {
-			desc = dimStyle.Render(" — " + v.Description)
+			desc = ui.DimStyle.Render(" — " + v.Description)
 		}
 
-		line := fmt.Sprintf("%s%s%s", prefix, titleStyle.Render(v.Name), desc)
+		line := fmt.Sprintf("%s%s%s", prefix, ui.TitleStyle.Render(v.Name), desc)
 		if i == m.cursor {
 			line = selRow(line)
 		}
@@ -435,33 +414,33 @@ func (m Model) renderViews() string {
 // dueIndicator shows target-date urgency: ! overdue, ● due this week, ○ has date.
 func dueIndicator(t model.Task) string {
 	if t.TargetDate.IsZero() {
-		return dimStyle.Render("—")
+		return ui.DimStyle.Render("—")
 	}
 	now := time.Now()
 	if t.TargetDate.Before(now) && t.State != model.StateDone && t.State != model.StateClosed {
-		return overdueStyle.Render("!")
+		return ui.OverdueStyle.Render("!")
 	}
 	if t.TargetDate.Before(now.AddDate(0, 0, 7)) {
-		return dueSoonStyle.Render("●")
+		return ui.DueSoonStyle.Render("●")
 	}
-	return dimStyle.Render("○")
+	return ui.DimStyle.Render("○")
 }
 
 // activityIndicator shows freshness based on last update: ● green/blue/yellow/red.
 func activityIndicator(t model.Task) string {
 	if t.UpdatedAt.IsZero() {
-		return dimStyle.Render("—")
+		return ui.DimStyle.Render("—")
 	}
 	d := time.Since(t.UpdatedAt)
 	switch {
 	case d < 24*time.Hour:
-		return freshStyle.Render("●")
+		return ui.FreshStyle.Render("●")
 	case d < 7*24*time.Hour:
-		return recentStyle.Render("●")
+		return ui.RecentStyle.Render("●")
 	case d < 30*24*time.Hour:
-		return agingStyle.Render("●")
+		return ui.AgingStyle.Render("●")
 	default:
-		return staleStyle.Render("●")
+		return ui.StaleStyle.Render("●")
 	}
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -50,6 +50,33 @@ func (s *Store) Get(key string, ttl time.Duration) (*Entry, error) {
 	return &e, nil
 }
 
+// UIState holds persisted UI preferences.
+type UIState struct {
+	ActiveTab int `json:"active_tab"`
+}
+
+// uiStateKey is the cache key used for UIState entries.
+const uiStateKey = "state"
+
+// LoadUIState reads the persisted UI state. Returns a zero-value UIState if
+// none exists yet.
+func (s *Store) LoadUIState() UIState {
+	e, _ := s.Get(uiStateKey, 0)
+	if e == nil {
+		return UIState{}
+	}
+	var st UIState
+	if err := json.Unmarshal(e.Data, &st); err != nil {
+		return UIState{}
+	}
+	return st
+}
+
+// SaveUIState persists the UI state to disk.
+func (s *Store) SaveUIState(st UIState) error {
+	return s.Set(uiStateKey, st)
+}
+
 // Set writes data to the cache, stamped with the current time and config key.
 func (s *Store) Set(key string, data any) error {
 	raw, err := json.Marshal(data)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -1,0 +1,59 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// Catppuccin Mocha palette
+const (
+	catMauve    = "#cba6f7"
+	catRed      = "#f38ba8"
+	catYellow   = "#f9e2af"
+	catGreen    = "#a6e3a1"
+	catBlue     = "#89b4fa"
+	catText     = "#cdd6f4"
+	catOverlay2 = "#9399b2"
+	catOverlay0 = "#6c7086"
+	catSurface2 = "#585b70"
+)
+
+var (
+	TabStyle = lipgloss.NewStyle().Padding(0, 2)
+
+	ActiveTabStyle = lipgloss.NewStyle().
+			Padding(0, 2).
+			Bold(true).
+			Foreground(lipgloss.Color(catMauve))
+
+	TitleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color(catMauve))
+
+	DimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catOverlay0))
+
+	FilterStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catYellow))
+
+	StatusStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catOverlay2))
+
+	CountStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catBlue))
+
+	TypeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catText))
+
+	BorderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(catSurface2)).
+			Padding(1, 2)
+
+	// Indicator styles
+	OverdueStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catRed))
+	DueSoonStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(catYellow))
+	FreshStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(catGreen))
+	RecentStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(catBlue))
+	AgingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(catYellow))
+	StaleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color(catRed))
+
+	// State colors (for use in stateColors map in view.go)
+	StateTodoColor       = lipgloss.NewStyle().Foreground(lipgloss.Color(catSurface2))
+	StateInProgressColor = lipgloss.NewStyle().Foreground(lipgloss.Color(catBlue))
+	StateInReviewColor   = lipgloss.NewStyle().Foreground(lipgloss.Color(catYellow))
+	StateDoneColor       = lipgloss.NewStyle().Foreground(lipgloss.Color(catGreen))
+	StateClosedColor     = lipgloss.NewStyle().Foreground(lipgloss.Color(catOverlay0))
+)


### PR DESCRIPTION
## Summary
- **Logging**: dedicated `setupLog()` with `log.SetOutput`/`log.SetFlags` (timestamps + source locations)
- **CLI flags**: `-v`/`--version` and `-h`/`--help` handling
- **Version injection**: `var version = "dev"` with GoReleaser ldflags, replacing hardcoded `"0.1.0"`
- **GoReleaser**: `.goreleaser.yaml` + Release CI job for automated builds and Homebrew tap
- **CONTRIBUTING.md**: adapted from grove with canopy-specific project structure and prerequisites
- **UI styles**: extracted inline Catppuccin Mocha hex codes to `internal/ui/styles.go`
- **Tab persistence**: save/restore active tab via cache `UIState`

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test -race ./...` passes
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] CI Check passes on dev push
- [ ] CI Check + Release passes on this PR